### PR TITLE
[0.x] Moves facade to its folder

### DIFF
--- a/src/Facades/Folio.php
+++ b/src/Facades/Folio.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Laravel\Folio;
+namespace Laravel\Folio\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use Laravel\Folio\FolioManager;
 
 /**
  * @method static \Laravel\Folio\FolioManager route(?string $path = null, ?string $uri = '/', array $middleware = [])

--- a/tests/Feature/MiddlewareTest.php
+++ b/tests/Feature/MiddlewareTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Laravel\Folio\Folio;
+use Laravel\Folio\Facades\Folio;
 
 beforeEach(function () {
     $_SERVER['__folio_users_middleware'] = false;

--- a/tests/Feature/ModelBindingTest.php
+++ b/tests/Feature/ModelBindingTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Schema;
-use Laravel\Folio\Folio;
+use Laravel\Folio\Facades\Folio;
 use Tests\Feature\Fixtures\Podcast;
 
 beforeEach(function () {


### PR DESCRIPTION
We could relocate Folio's facade to the `Facades` namespace, similar to Laravel Octane, as it appears more aesthetically pleasing than using `Laravel\Folio\Folio;`

```php
use Illuminate\Support\Facades\Route;
use Laravel\Folio\Facades\Folio;

class RouteServiceProvider extends ServiceProvider
{
    /**
     * Define your route model bindings, pattern filters, and other route configuration.
     */
    public function boot(): void
    {
        Route::middleware('web')->group(base_path('routes/web.php'));

        Folio::route(resource_path('views/pages'));
    }
}
```