### PR TITLE
[0.x] Removes `symfony/finder`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
         "illuminate/pipeline": "^10.0",
         "illuminate/routing": "^10.0",
         "illuminate/support": "^10.0",
-        "spatie/once": "^3.1",
-        "symfony/finder": "^6.0"
+        "spatie/once": "^3.1"
     },
     "require-dev": {
         "orchestra/testbench": "^8.0",


### PR DESCRIPTION
This pull request removes `symfony/finder` as we are not even using it. At least, directly.