### PR TITLE
[0.x] Removes `prop` function

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -18,8 +18,3 @@ function page(Closure|string|array $middleware = [], bool $withTrashed = false)
         );
     }
 }
-
-function prop(?string $key = null, mixed $default = null): mixed
-{
-    return Folio::data($key, $default);
-}


### PR DESCRIPTION
This pull request should be merged if https://github.com/laravel/volt/pull/48/files gets merged. As the `prop` function no longer have a valid usage.