### PR TITLE
[0.x] Improves `folio:install`

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -3,6 +3,7 @@
 namespace Laravel\Folio\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 
 class InstallCommand extends Command
@@ -32,7 +33,21 @@ class InstallCommand extends Command
 
         $this->registerFolioServiceProvider();
 
+        $this->ensurePagesDirectoryExists();
+
         $this->components->info('Folio scaffolding installed successfully.');
+    }
+
+    /**
+     * Ensure the pages directory exists.
+     */
+    protected function ensurePagesDirectoryExists(): void
+    {
+        if (! is_dir($directory = resource_path('views/pages'))) {
+            File::ensureDirectoryExists($directory);
+
+            File::put($directory.'/.gitkeep', '');
+        }
     }
 
     /**


### PR DESCRIPTION
Similar to Volt, we use our build-in components for better console output. In addition, I've ensured the `pages` directory exists so we don't see an exception when trying to "mount" Folio.