### PR TITLE
Add `ViewMatched` event

### DIFF
--- a/src/Events/ViewMatched.php
+++ b/src/Events/ViewMatched.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\Folio\Events;
+
+use Laravel\Folio\MountPath;
+use Laravel\Folio\Pipeline\MatchedView;
+
+class ViewMatched
+{
+    /**
+     * Create a new view matched event instance.
+     */
+    public function __construct(
+        public MatchedView $matchedView,
+        public MountPath $mountPath,
+    ) {}
+}

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -3,6 +3,7 @@
 namespace Laravel\Folio;
 
 use Closure;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Pipeline;
@@ -29,6 +30,8 @@ class RequestHandler
         $matchedView = (new Router(
             $this->mountPath->path
         ))->match($request, $uri) ?? abort(404);
+
+        app(Dispatcher::class)->dispatch(new Events\ViewMatched($matchedView, $this->mountPath));
 
         return (new Pipeline(app()))
             ->send($request)

--- a/tests/Feature/ManagerTest.php
+++ b/tests/Feature/ManagerTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
+use Laravel\Folio\Events\ViewMatched;
 use Laravel\Folio\Folio;
 use Laravel\Folio\Pipeline\MatchedView;
 
@@ -51,4 +53,30 @@ it('registers routes with custom render callback', function () {
     expect($path)->toBe(__DIR__.'/resources/views/pages/users/[id].blade.php')
         ->and($data)->toBe(['id' => 'Taylor'])
         ->and($mountPath)->toBe(__DIR__.'/resources/views/pages');
+});
+
+it('fires view matched event on route', function () {
+    Folio::route(__DIR__.'/resources/views/pages');
+
+    $events = Event::fake(ViewMatched::class);
+
+    $response = $this->get('/users/Taylor');
+
+    $response->assertOk();
+
+    $events->assertDispatched(ViewMatched::class, function ($event) {
+        return $event->matchedView->path === __DIR__.'/resources/views/pages/users/[id].blade.php';
+    });
+});
+
+it('doesn\'t fire view matched event on 404', function () {
+    Folio::route(__DIR__.'/resources/views/pages');
+
+    $events = Event::fake(ViewMatched::class);
+
+    $response = $this->get('/invalid-route');
+
+    $response->assertNotFound();
+
+    $events->assertNotDispatched(ViewMatched::class);
 });


### PR DESCRIPTION
It would be really helpful to have an event when a view is matched so logging can be done or context can be set based on it. My current use case for this is [Sentry](https://github.com/getsentry/sentry-laravel) where we'd like to show a nicer URL based on the view name.

I used `app()` to get the dispatcher since that is also used a in other places but maybe that should be done differently.