### PR TITLE
Fix for making a route model binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ php artisan make:folio users/index
 Often, you will need to have segments of the incoming request's URL injected into your page so that you can interact with them. For example, you may need to access the "ID" of the user whose profile is being displayed. To accomplish this, you may encapsulate a segment of the page's filename in square brackets:
 
 ```bash
-php artisan make:folio users/[id]
+php artisan make:folio "users/[id]"
 
 # pages/users/[id].blade.php → /users/1
 ```
@@ -111,7 +111,7 @@ Captured segments can be accessed as variables within your Blade template:
 To capture multiple segments, you can prefix the encapsulated segment with three dots `...`:
 
 ```bash
-php artisan make:folio user/[...ids]
+php artisan make:folio "user/[...ids]"
 
 # pages/users/[...ids].blade.php → /users/1/2/3
 ```

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Sometimes you may wish to resolve bound Eloquent models using a column other tha
 By default, Folio will search for your model within your application's `app/Models` directory. However, if needed, you may specify the fully-qualified model class name in your template's filename:
 
 ```bash
-php artisan make:folio user/[.App.Models.User]
+php artisan make:folio "user/[.App.Models.User]"
 
 # pages/users/[.App.Models.User].blade.php → /users/1
 ```


### PR DESCRIPTION
If we run a command like `php artisan make:folio users/[id]`, especially when we are using iTerm with oh my zsh. 
```
It will say zsh: no matches found: users/[id].
```

To fix this, just add double/single quotes to the name given like:

```bash
php artisan make:folio "users/[id]"

# or with single quote
php artisan make:folio 'users/[User.username]'
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
