### PR TITLE
Docs: fixing for Route Model Binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ When capturing multiple segments, the captured segments will be injected into th
 If a wildcard segment of your page template's filename corresponds one of your application's Eloquent models, Folio will automatically take advantage of Laravel's route model binding capabilities and attempt to inject the resolved model instance into your page:
 
 ```bash
-php artisan make:folio users/[User]
+php artisan make:folio "users/[User]"
 
 # pages/users/[User].blade.php → /users/1
 ```


### PR DESCRIPTION
TL;DR: it is just a little improvement after #38 

If we run a command like `php artisan make:folio users/[User]`, especially when we are using iTerm with oh my zsh.

```bash
zsh: no matches found: users/[User]
```

To fix this, just add double/single quotes to the name given like:

```bash
php artisan make:folio "users/[User]"

# or with single quote
php artisan make:folio 'users/[User]'

# result
[INFO]  Page [resources/views/pages/users/[User].blade.php] created successfully.
```