### PR TITLE
Add support for dynamic file extensions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ use Laravel\Folio\Folio;
 Folio::extension('.vue')
 ```
 
-In concert with Inertia, changing the file extension allows you to render React, Vue, or Svelte files as Folio pages:
+In concert with Inertia, changing the file extension allows you to render React, Vue, or Svelte files as Folio pages where the route parameters are passed as props:
 ```php
 use Illuminate\Http\Request;
 use Laravel\Folio\Folio;
@@ -261,8 +261,8 @@ Folio::extension('.vue');
 Folio::renderUsing(
     function (Request $request, MatchedView $view) {
         return Inertia::render(
-            $matchedView->componentPath(), 
-            $matchedView->data
+            $view->componentPath(), 
+            $view->data
         );
     }
 );

--- a/README.md
+++ b/README.md
@@ -238,6 +238,36 @@ Folio::route(resource_path('views/pages'), middleware: [
 ]);
 ```
 
+<a name="rendering"></a>
+## Rendering
+You can tap into Folio to create a custom response such as swapping blade files for Inertia pages written with React, Vue, or Svelte.
+
+By default Folio looks for a `.blade.php` extension when validating routes. You may instruct Folio to look for a different file extension:
+```php
+use Laravel\Folio\Folio;
+
+Folio::extension('.vue')
+```
+
+In concert with Inertia, changing the file extension allows you to render React, Vue, or Svelte files as Folio pages:
+```php
+use Illuminate\Http\Request;
+use Laravel\Folio\Folio;
+use Laravel\Folio\Pipeline\MatchedView;
+use Inertia\Inertia;
+
+Folio::extension('.vue');
+
+Folio::renderUsing(
+    function (Request $request, MatchedView $view) {
+        return Inertia::render(
+            $matchedView->componentPath(), 
+            $matchedView->data
+        );
+    }
+);
+```
+
 <a name="php-blocks"></a>
 ## PHP Blocks
 

--- a/src/Console/ListCommand.php
+++ b/src/Console/ListCommand.php
@@ -5,6 +5,7 @@ namespace Laravel\Folio\Console;
 use Illuminate\Foundation\Console\RouteListCommand;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Laravel\Folio\Folio;
 use Laravel\Folio\FolioManager;
 use Laravel\Folio\MountPath;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -67,7 +68,7 @@ class ListCommand extends RouteListCommand
         return collect($mountPaths)->map(function (MountPath $mountPath) {
             $path = '/'.ltrim($mountPath->path, '/');
 
-            $views = Finder::create()->in($mountPath->path)->name('*.blade.php')->files()->getIterator();
+            $views = Finder::create()->in($mountPath->path)->name('*'.Folio::extension())->files()->getIterator();
 
             return collect($views)
                 ->map(function (SplFileInfo $view) use ($mountPath) {
@@ -85,7 +86,7 @@ class ListCommand extends RouteListCommand
                         $action = str_replace($basePath, '', $view->getRealPath());
                     }
 
-                    $uri = str_replace('.blade.php', '', $uri);
+                    $uri = str_replace(Folio::extension(), '', $uri);
 
                     $uri = collect(explode('/', $uri))
                         ->map(function (string $segment) {

--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -43,7 +43,7 @@ class MakeCommand extends GeneratorCommand
 
         return $mountPath.'/'.preg_replace_callback('/(?:\[.*?\])|(\w+)/', function (array $matches) {
             return empty($matches[1]) ? $matches[0] : Str::lower($matches[1]);
-        }, Str::finish($this->argument('name'), '.blade.php'));
+        }, Str::finish($this->argument('name'), Folio::extension()));
     }
 
     /**

--- a/src/Folio.php
+++ b/src/Folio.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Laravel\Folio\FolioManager renderUsing(\Closure|null $callback = null)
  * @method static array mountPaths()
  * @method static array paths()
+ * @method static string extension(string|null $extension = null)
  *
  * @see \Laravel\Folio\FolioManager
  */

--- a/src/Folio.php
+++ b/src/Folio.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static array mountPaths()
  * @method static array paths()
  * @method static string extension(string|null $extension = null)
+ * @method static \Laravel\Folio\FolioManager withExtension(string $extension)
  *
  * @see \Laravel\Folio\FolioManager
  */

--- a/src/FolioManager.php
+++ b/src/FolioManager.php
@@ -49,6 +49,8 @@ class FolioManager
 
         $this->mountPaths[] = $mountPath = new MountPath($path, $uri, $middleware);
 
+        $mountPath->extension($this->extension());
+
         if ($uri === '/') {
             Route::fallback($this->handler($mountPath))
                 ->name($mountPath->routeName());
@@ -136,5 +138,12 @@ class FolioManager
     public function extension(string|null $extension='.blade.php'): string
     {
         return $this->pathExtension ??= $extension;
+    }
+
+    public function withExtension(string $extension): self
+    {
+        return tap($this, function () use ($extension) {
+            $this->pathExtension = $extension;
+        });
     }
 }

--- a/src/FolioManager.php
+++ b/src/FolioManager.php
@@ -11,6 +11,12 @@ use Laravel\Folio\Pipeline\MatchedView;
 
 class FolioManager
 {
+
+    /**
+     * The file extension to use while routing.
+     */
+    public string $pathExtension;
+
     /**
      * The mounted paths that have been registered.
      *
@@ -122,5 +128,13 @@ class FolioManager
     public function paths(): array
     {
         return collect($this->mountPaths)->map->path->all();
+    }
+
+    /**
+     * Register the file extension used while routing.
+     */
+    public function extension(string|null $extension='.blade.php'): string
+    {
+        return $this->pathExtension ??= $extension;
     }
 }

--- a/src/MountPath.php
+++ b/src/MountPath.php
@@ -9,6 +9,11 @@ class MountPath
      */
     public PathBasedMiddlewareList $middleware;
 
+     /**
+     * The file extension to use while routing.
+     */
+    public string $pathExtension;
+
     /**
      * Create a new mounted path instance.
      */
@@ -26,5 +31,13 @@ class MountPath
     public function routeName(): string
     {
         return 'folio-'.substr(sha1($this->baseUri), 0, 10);
+    }
+
+    /**
+     * Register the file extension used while routing.
+     */
+    public function extension(string|null $extension='.blade.php'): string
+    {
+        return $this->pathExtension ??= $extension;
     }
 }

--- a/src/Pipeline/FindsWildcardViews.php
+++ b/src/Pipeline/FindsWildcardViews.php
@@ -4,6 +4,7 @@ namespace Laravel\Folio\Pipeline;
 
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
+use Laravel\Folio\Folio;
 
 trait FindsWildcardViews
 {
@@ -33,11 +34,11 @@ trait FindsWildcardViews
         return collect($files)->first(function ($file) use ($startsWith, $endsWith) {
             $filename = Str::of($file->getFilename());
 
-            if (! $filename->endsWith('.blade.php')) {
+            if (! $filename->endsWith(Folio::extension())) {
                 return;
             }
 
-            $filename = $filename->before('.blade.php');
+            $filename = $filename->before(Folio::extension());
 
             return $filename->startsWith($startsWith) &&
                    $filename->endsWith($endsWith);

--- a/src/Pipeline/MatchDirectoryIndexViews.php
+++ b/src/Pipeline/MatchDirectoryIndexViews.php
@@ -3,6 +3,7 @@
 namespace Laravel\Folio\Pipeline;
 
 use Closure;
+use Laravel\Folio\Folio;
 
 class MatchDirectoryIndexViews
 {
@@ -13,7 +14,7 @@ class MatchDirectoryIndexViews
     {
         return $state->onLastUriSegment() &&
             $state->currentUriSegmentIsDirectory() &&
-            file_exists($path = $state->currentUriSegmentDirectory().'/index.blade.php')
+            file_exists($path = $state->currentUriSegmentDirectory().'/index'.Folio::extension())
                 ? new MatchedView($path, $state->data)
                 : $next($state);
     }

--- a/src/Pipeline/MatchLiteralViews.php
+++ b/src/Pipeline/MatchLiteralViews.php
@@ -3,6 +3,7 @@
 namespace Laravel\Folio\Pipeline;
 
 use Closure;
+use Laravel\Folio\Folio;
 
 class MatchLiteralViews
 {
@@ -12,7 +13,7 @@ class MatchLiteralViews
     public function __invoke(State $state, Closure $next): mixed
     {
         return $state->onLastUriSegment() &&
-            file_exists($path = $state->currentDirectory().'/'.$state->currentUriSegment().'.blade.php')
+            file_exists($path = $state->currentDirectory().'/'.$state->currentUriSegment().Folio::extension())
                 ? new MatchedView($path, $state->data)
                 : $next($state);
     }

--- a/src/Pipeline/MatchRootIndex.php
+++ b/src/Pipeline/MatchRootIndex.php
@@ -3,6 +3,7 @@
 namespace Laravel\Folio\Pipeline;
 
 use Closure;
+use Laravel\Folio\Folio;
 
 class MatchRootIndex
 {
@@ -12,7 +13,7 @@ class MatchRootIndex
     public function __invoke(State $state, Closure $next): mixed
     {
         if (trim($state->uri) === '/') {
-            return file_exists($path = $state->mountPath.'/index.blade.php')
+            return file_exists($path = $state->mountPath.'/index'.Folio::extension())
                     ? new MatchedView($path, $state->data)
                     : new StopIterating;
         }

--- a/src/Pipeline/MatchWildcardViews.php
+++ b/src/Pipeline/MatchWildcardViews.php
@@ -4,6 +4,7 @@ namespace Laravel\Folio\Pipeline;
 
 use Closure;
 use Illuminate\Support\Str;
+use Laravel\Folio\Folio;
 
 class MatchWildcardViews
 {
@@ -18,7 +19,7 @@ class MatchWildcardViews
             $path = $this->findWildcardView($state->currentDirectory())) {
             return new MatchedView($state->currentDirectory().'/'.$path, $state->withData(
                 Str::of($path)
-                    ->before('.blade.php')
+                    ->before(Folio::extension())
                     ->match('/\[(.*)\]/')->value(),
                 $state->currentUriSegment(),
             )->data);

--- a/src/Pipeline/MatchWildcardViewsThatCaptureMultipleSegments.php
+++ b/src/Pipeline/MatchWildcardViewsThatCaptureMultipleSegments.php
@@ -4,6 +4,7 @@ namespace Laravel\Folio\Pipeline;
 
 use Closure;
 use Illuminate\Support\Str;
+use Laravel\Folio\Folio;
 
 class MatchWildcardViewsThatCaptureMultipleSegments
 {
@@ -17,7 +18,7 @@ class MatchWildcardViewsThatCaptureMultipleSegments
         if ($path = $this->findWildcardMultiSegmentView($state->currentDirectory())) {
             return new MatchedView($state->currentDirectory().'/'.$path, $state->withData(
                 Str::of($path)
-                    ->before('.blade.php')
+                    ->before(Folio::extension())
                     ->match('/\[\.\.\.(.*)\]/')->value(),
                 array_slice(
                     $state->segments,

--- a/src/Pipeline/MatchedView.php
+++ b/src/Pipeline/MatchedView.php
@@ -3,7 +3,9 @@
 namespace Laravel\Folio\Pipeline;
 
 use Illuminate\Support\Collection;
+use Laravel\Folio\Folio;
 use Laravel\Folio\InlineMetadataInterceptor;
+use Illuminate\Support\Str;
 
 class MatchedView
 {
@@ -50,6 +52,17 @@ class MatchedView
         $path = str_replace($this->mountPath, '', $this->path);
 
         return '/'.trim(str_replace(DIRECTORY_SEPARATOR, '/', $path), '/');
+    }
+
+    /**
+     * Get the matched relative path without the file extension.
+     */
+    public function componentPath(): string
+    {
+        $path = str_replace($this->mountPath, '', $this->path);
+        return Str::of(str_replace(DIRECTORY_SEPARATOR, '/', $path))
+            ->trim('/')
+            ->before(Folio::extension());
     }
 
     /**

--- a/src/Pipeline/TransformModelBindings.php
+++ b/src/Pipeline/TransformModelBindings.php
@@ -5,6 +5,7 @@ namespace Laravel\Folio\Pipeline;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
+use Laravel\Folio\Folio;
 
 class TransformModelBindings
 {
@@ -81,7 +82,7 @@ class TransformModelBindings
     {
         return explode('/', (string) Str::of($view->path)
             ->replace($view->mountPath, '')
-            ->beforeLast('.blade.php')
+            ->beforeLast(Folio::extension())
             ->trim('/'));
     }
 

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -28,6 +28,8 @@ class RequestHandler
      */
     public function __invoke(Request $request, string $uri): mixed
     {
+        Folio::withExtension($this->mountPath->extension());
+
         $matchedView = (new Router(
             $this->mountPath->path
         ))->match($request, $uri) ?? abort(404);

--- a/tests/Feature/resources/js/Pages/stories/[year]/[month]/[day]/[slug].svelte
+++ b/tests/Feature/resources/js/Pages/stories/[year]/[month]/[day]/[slug].svelte
@@ -1,0 +1,17 @@
+<script>
+    import { page } from '@inertiajs/svelte'
+</script>
+
+<dl>
+    <dt>Year</dt>
+    <dd>{$page.props.year}</dd>
+
+    <dt>Month</dt>
+    <dd>{$page.props.month}</dd>
+
+    <dt>Day</dt>
+    <dd>{$page.props.day}</dd>
+
+    <dt>Slug</dt>
+    <dd>{$page.props.slug}</dd>
+  </dl>


### PR DESCRIPTION
Makes it possible to support non `.blade.php` extensions. Intended for use with Inertia.

Syntax:
```php
Folio::extension('.vue')
```

Example Inertia renderer for Folio:
```php
use Illuminate\Http\Request;
use Laravel\Folio\Folio;
use Laravel\Folio\Pipeline\MatchedView;
use Inertia\Inertia;

//...

Folio::extension('.vue');

Folio::renderUsing(function (Request $request, MatchedView $matchedView) {
    return Inertia::render($matchedView->componentPath(), $matchedView->data);
});

Folio::route(resource_path('js/Pages'), middleware: [
    '*' => [
        //
    ],
]);
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
