### PR TITLE
[1.x] Add support for "page names"

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -30,3 +30,11 @@ function withTrashed(bool $withTrashed = true): PageOptions
 
     return new PageOptions;
 }
+
+/**
+ * Generate the URL to a Folio page.
+ */
+function url(string $name, array $parameters = []): string
+{
+    return Folio::url($name, $parameters);
+}

--- a/src/Exceptions/NameNotFoundException.php
+++ b/src/Exceptions/NameNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Folio\Exceptions;
+
+use Exception;
+
+class NameNotFoundException extends Exception
+{
+    //
+}

--- a/src/Exceptions/UrlGenerationException.php
+++ b/src/Exceptions/UrlGenerationException.php
@@ -6,6 +6,9 @@ use Exception;
 
 class UrlGenerationException extends Exception
 {
+    /**
+     * Create a new exception for a missing URL parameter.
+     */
     public static function forMissingParameter(string $path, string $parameter): static
     {
         return new static(sprintf(

--- a/src/Exceptions/UrlGenerationException.php
+++ b/src/Exceptions/UrlGenerationException.php
@@ -12,9 +12,9 @@ class UrlGenerationException extends Exception
     public static function forMissingParameter(string $path, string $parameter): static
     {
         return new static(sprintf(
-            'Missing required parameter for [Path: %s] [Missing parameter: %s]',
+            'Missing required parameter for [Path: %s] [Missing parameter: %s].',
             $path,
-            $parameter
+            $parameter,
         ));
     }
 }

--- a/src/Exceptions/UrlGenerationException.php
+++ b/src/Exceptions/UrlGenerationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\Folio\Exceptions;
+
+use Exception;
+
+class UrlGenerationException extends Exception
+{
+    public static function forMissingParameter(string $path, string $parameter): static
+    {
+        return new static(sprintf(
+            'Missing required parameter for [Path: %s] [Missing parameter: %s]',
+            $path,
+            $parameter
+        ));
+    }
+}

--- a/src/Folio.php
+++ b/src/Folio.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static static route(string|null $path = null, string|null $uri = '/', array $middleware = [])
  * @method static array middlewareFor(string $uri)
  * @method static mixed|null data(string|null $key = null, mixed|null $default = null)
+ * @method static string url(string $name, array $parameters = [])
  * @method static \Laravel\Folio\FolioManager renderUsing(\Closure|null $callback = null)
  * @method static array mountPaths()
  * @method static array paths()

--- a/src/FolioManager.php
+++ b/src/FolioManager.php
@@ -31,6 +31,9 @@ class FolioManager
      */
     protected ?MatchedView $lastMatchedView = null;
 
+    /**
+     * Create a new Folio manager instance.
+     */
     public function __construct(
         protected UrlGenerator $urlGenerator,
     ) {}

--- a/src/MountPath.php
+++ b/src/MountPath.php
@@ -16,6 +16,7 @@ class MountPath
         public string $path,
         public string $baseUri,
         array $middleware = [],
+        public array $names = [],
     ) {
         $this->middleware = new PathBasedMiddlewareList($middleware);
     }

--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Laravel\Folio;
+
+use BackedEnum;
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Support\Str;
+use Laravel\Folio\Exceptions\UrlGenerationException;
+use Laravel\Folio\Pipeline\PotentiallyBindablePathSegment;
+
+class UrlGenerator
+{
+    /**
+     * Generate the URL to a Folio page.
+     *
+     * @param  \Laravel\Folio\MountPath  $mountPath
+     * @param  string  $path
+     * @param  array  $parameters
+     * @return string
+     *
+     * @throws \Laravel\Folio\Exceptions\UrlGenerationException
+     */
+    public function path(MountPath $mountPath, string $path, array $parameters = []): string
+    {
+        $uri = str_replace('.blade.php', '', $path);
+
+        $uri = collect(explode('/', $uri))
+            ->map(function (string $segment) use ($parameters, $uri) {
+                if (! Str::startsWith($segment, '[')) {
+                    return $segment;
+                }
+
+                $segment = new PotentiallyBindablePathSegment($segment);
+                $name = $segment->variable();
+
+                if (! isset($parameters[$name])) {
+                    throw UrlGenerationException::forMissingParameter($uri, $name);
+                }
+
+                return $this->formatParameter($parameters[$name], $segment->field(), $segment->capturesMultipleSegments());
+            })
+            ->implode('/');
+
+        $uri = str_replace(['/index', '/index/'], ['', '/'], $uri);
+
+        return ltrim($mountPath->baseUri, '/') . '/' . $uri;
+    }
+
+    protected function formatParameter(mixed $parameter, string|bool $field, bool $variadic): mixed
+    {
+        if ($parameter instanceof UrlRoutable && $field !== false) {
+            return $parameter->{$field};
+        }
+
+        if ($parameter instanceof UrlRoutable) {
+            return $parameter->getRouteKey();
+        }
+
+        if ($parameter instanceof BackedEnum) {
+            return $parameter->value;
+        }
+
+        if ($variadic) {
+            return implode(
+                '/',
+                collect($parameter)
+                    ->map(fn (mixed $value) => $this->formatParameter($value, $field, false))
+                    ->all()
+            );
+        }
+
+        return $parameter;
+    }
+}

--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -13,11 +13,6 @@ class UrlGenerator
     /**
      * Generate the URL to a Folio page.
      *
-     * @param  \Laravel\Folio\MountPath  $mountPath
-     * @param  string  $path
-     * @param  array  $parameters
-     * @return string
-     *
      * @throws \Laravel\Folio\Exceptions\UrlGenerationException
      */
     public function path(MountPath $mountPath, string $path, array $parameters = []): string
@@ -46,6 +41,9 @@ class UrlGenerator
         return ltrim($mountPath->baseUri, '/') . '/' . $uri;
     }
 
+    /**
+     * Formats the given URL parameter.
+     */
     protected function formatParameter(mixed $parameter, string|bool $field, bool $variadic): mixed
     {
         if ($parameter instanceof UrlRoutable && $field !== false) {

--- a/tests/Feature/UrlTest.php
+++ b/tests/Feature/UrlTest.php
@@ -4,6 +4,7 @@ use Tests\Feature\Fixtures\User;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Laravel\Folio\Exceptions\NameNotFoundException;
+use Laravel\Folio\Exceptions\UrlGenerationException;
 use Laravel\Folio\Folio;
 use Tests\Feature\Fixtures\Book;
 use Tests\Feature\Fixtures\Category;
@@ -107,6 +108,13 @@ test('generate url with variadic segment with custom variable', function () {
 
     expect($url)->toBe('/books/1/2/3');
 });
+
+it('throws exception when a url parameter is missing', function () {
+    url('users.show');
+})->throws(
+    UrlGenerationException::class,
+    'Missing required parameter for [Path: users/[id]] [Missing parameter: id]'
+);
 
 it('throws exception when generating url for unknown name', function () {
     url('non-existent');

--- a/tests/Feature/UrlTest.php
+++ b/tests/Feature/UrlTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use Tests\Feature\Fixtures\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Folio\Exceptions\NameNotFoundException;
+use Laravel\Folio\Folio;
+use Tests\Feature\Fixtures\Book;
+use Tests\Feature\Fixtures\Category;
+use Tests\Feature\Fixtures\Comment;
+use Tests\Feature\Fixtures\Podcast;
+
+use function Laravel\Folio\url;
+
+beforeEach(function () {
+    Folio::route(__DIR__ . '/resources/views/pages', names: [
+        'flights.index' => 'flights/index.blade.php',
+        'users.show' => 'users/[id].blade.php',
+        'categories.show' => 'categories/[.Tests.Feature.Fixtures.Category].blade.php',
+        'podcasts.comments.index' => 'podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/index.blade.php',
+        'podcasts.comments.show' => 'podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/[.Tests.Feature.Fixtures.Comment:id].blade.php',
+        'books.detail' => 'books/[...Tests.Feature.Fixtures.Book]/detail.blade.php',
+        'books.show' => 'books/[id:$theId]',
+        'books.many' => 'books/[...id:$theIds]',
+    ]);
+});
+
+test('generate url for basic page', function () {
+    $url = url('flights.index');
+
+    expect($url)->toBe('/flights');
+});
+
+test('generate url with simple parameter', function () {
+    $url = url('users.show', ['id' => 1]);
+
+    expect($url)->toBe('/users/1');
+});
+
+test('generate url with UrlRoutable parameter', function () {
+    $user = new User(['id' => 1]);
+    $url = url('users.show', ['id' => $user]);
+
+    expect($url)->toBe('/users/1');
+});
+
+test('generate url with BackedEnum parameter', function () {
+    $url = url('categories.show', ['category' => Category::Post]);
+
+    expect($url)->toBe('/categories/posts');
+});
+
+test('generate url with parameter mid-path', function () {
+    $podcast = new Podcast(['id' => 1]);
+    $url = url('podcasts.comments.index', ['podcast' => $podcast]);
+
+    expect($url)->toBe('/podcasts/1/comments');
+});
+
+test('generate url with multiple parameters', function () {
+    $podcast = new Podcast(['id' => 1]);
+    $comment = new Comment(['id' => 2]);
+    $url = url('podcasts.comments.show', ['podcast' => $podcast, 'comment' => $comment]);
+
+    expect($url)->toBe('/podcasts/1/comments/2');
+});
+
+test('generate url with variadic segment', function () {
+    $books = [
+        new Book(['id' => 1]),
+        new Book(['id' => 2]),
+        new Book(['id' => 3]),
+    ];
+
+    $url = url('books.detail', ['books' => $books]);
+
+    expect($url)->toBe('/books/1/2/3/detail');
+});
+
+test('generate url with variadic segment passed as a Collection', function () {
+    $books = collect([
+        new Book(['id' => 1]),
+        new Book(['id' => 2]),
+        new Book(['id' => 3]),
+    ]);
+
+    $url = url('books.detail', ['books' => $books]);
+
+    expect($url)->toBe('/books/1/2/3/detail');
+});
+
+test('generate url with variadic segment passing a single value', function () {
+    $book = new Book(['id' => 1]);
+    $url = url('books.detail', ['books' => $book]);
+
+    expect($url)->toBe('/books/1/detail');
+});
+
+test('generate url with segment with custom variable', function () {
+    $url = url('books.show', ['theId' => 1]);
+
+    expect($url)->toBe('/books/1');
+});
+
+test('generate url with variadic segment with custom variable', function () {
+    $url = url('books.many', ['theIds' => [1, 2, 3]]);
+
+    expect($url)->toBe('/books/1/2/3');
+});
+
+it('throws exception when generating url for unknown name', function () {
+    url('non-existent');
+})->throws(
+    NameNotFoundException::class,
+    'Page [non-existent] not found.'
+);


### PR DESCRIPTION
Related to #48.

There's currently no way to generate the URL to a Folio page by name, similar to how `route('foo')` works. This pull request aims to introduce that functionality.

The `Folio::route()` method inside of your `FolioServiceProvider` now has an additional parameter `$names`. This is an array of key-value pairs where the key is the pretty-name for the page and the value is the path to the Blade file.

```php
Folio::route(
    path: resource_path('views/pages'),
    names: [
        'users.index' => 'users/index.blade.php',
        'users.show' => 'user/[User].blade.php',
    ]
);
```

By registering these names, it's then possible to use the `Laravel\Folio\url()` function to generate URLs in a similar fashion to `route().`

```blade
<a href="{{ Laravel\Folio\url('users.index') }}">
    Users
</a>

<a href="{{ Laravel\Folio\url('users.show', $user) }}">
    John Doe
</a>

<a href="{{ Laravel\Folio\url('users.show', ['user' => $user]) }}">
    John Doe
</a>
```

The rules for the parameters:
* If the page has a simple name, `[id]`, then the parameter key should be `id`.
* If the page has a model/enum binding, `[User]`, then the parameter key matches the variable name `user`.
* If the page has a variadic/spread binding, `[...ids]` then the parameter key matches the variable name `$ids`.
* If the page has a custom variable binding, `[...ids:$theIds]` then the parameter key matches the custom variable name `theIds`.

This pull request is a "part 1" - the follow up to this work would be having a `name()` function that can be called from the Blade file itself, then a `folio:cache` command or similar that scans files for these function calls. The DX would be much better, as the cost of a small performance penalty when working locally.