### PR TITLE
Adds Ability to customize Folio Routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,15 @@
 - [Introduction](#introduction)
 - [Installation](#installation)
 - [Creating Routes](#creating-routes)
-    - [Nested Routes](#nested-routes)
-    - [Index Routes](#index-routes)
+  - [Nested Routes](#nested-routes)
+  - [Index Routes](#index-routes)
 - [Route Parameters](#route-parameters)
 - [Route Model Binding](#route-model-binding)
-    - [Soft Deleted Models](#soft-deleted-models)
+    - [Customizing The Key](#customizing-the-key)
+    - [Model Location](#model-location)
+  - [Soft Deleted Models](#soft-deleted-models)
 - [Middleware](#middleware)
+- [Loading Routes](#loading-routes)
 - [PHP Blocks](#php-blocks)
 - [Contributing](#contributing)
 - [Code of Conduct](#code-of-conduct)
@@ -237,6 +240,30 @@ Folio::route(resource_path('views/pages'), middleware: [
     ],
 ]);
 ```
+
+<a name="loading-routes"></a>
+## Loading Routes
+
+You may add a custom loader for folio routes using a callback function or a callable class:
+
+```php
+use Laravel\Folio\MountPath;
+
+Folio::route(__DIR__.'/resources/views/pages', loader: function(string $uri, MountPath $mountPath, Closure $handler){
+
+    if ($uri === '/') {
+        Route::fallback($hander)
+            ->name($mountPath->routeName());
+    } else {
+        Route::get(
+            '/'.trim($uri, '/').'/{uri?}',
+            $handler
+        )->name($mountPath->routeName())->where('uri', '.*');
+    }
+});
+
+```
+
 
 <a name="php-blocks"></a>
 ## PHP Blocks

--- a/README.md
+++ b/README.md
@@ -249,10 +249,10 @@ You may add a custom loader for folio routes using a callback function or a call
 ```php
 use Laravel\Folio\MountPath;
 
-Folio::route(__DIR__.'/resources/views/pages', loader: function(string $uri, MountPath $mountPath, Closure $handler){
+Folio::route(resource_path('views/pages'), loader: function(string $uri, MountPath $mountPath, Closure $handler){
 
     if ($uri === '/') {
-        Route::fallback($hander)
+        Route::fallback($handler)
             ->name($mountPath->routeName());
     } else {
         Route::get(

--- a/src/FolioManager.php
+++ b/src/FolioManager.php
@@ -33,7 +33,7 @@ class FolioManager
      *
      * @throws \InvalidArgumentException
      */
-    public function route(string $path = null, ?string $uri = '/', array $middleware = [], $loader = null): static
+    public function route(string $path = null, ?string $uri = '/', array $middleware = [], ?callable $loader = null): static
     {
         $path = $path ? realpath($path) : config('view.paths')[0].'/pages';
 
@@ -43,11 +43,11 @@ class FolioManager
 
         $this->mountPaths[] = $mountPath = new MountPath($path, $uri, $middleware);
 
-        if($loader && ! is_callable($loader)) {
-            throw new InvalidArgumentException("The given loader [{$loader}] is not callable.");
+       if($loader) {
+            $loader(uri: $uri, mountPath: $mountPath, handler: $this->handler($mountPath));
+        } else {
+            (new Loader())(uri: $uri, mountPath: $mountPath, handler: $this->handler($mountPath));
         }
-
-       $loader = $loader ? $loader(uri: $uri, mountPath: $mountPath, handler: $this->handler($mountPath)) : (new Loader())(uri: $uri, mountPath: $mountPath, handler: $this->handler($mountPath));
 
         return $this;
     }

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Laravel\Folio;
+
+use Closure;
+use Illuminate\Support\Facades\Route;
+
+class Loader
+{
+    /**
+     * Invoke the route loader.
+     */
+    public function __invoke(string $uri = '/', MountPath $mountPath, Closure $handler): void
+    {
+        if ($uri === '/') {
+            Route::fallback($handler)
+                ->name($mountPath->routeName());
+        } else {
+            Route::get(
+                '/'.trim($uri, '/').'/{uri?}',
+                $handler
+            )->name($mountPath->routeName())->where('uri', '.*');
+        }
+    }
+}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -10,7 +10,7 @@ class Loader
     /**
      * Invoke the route loader.
      */
-    public function __invoke(string $uri = '/', MountPath $mountPath, Closure $handler): void
+    public function __invoke(string $uri, MountPath $mountPath, Closure $handler): void
     {
         if ($uri === '/') {
             Route::fallback($handler)

--- a/tests/Feature/Fixtures/Loader.php
+++ b/tests/Feature/Fixtures/Loader.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Feature\Fixtures;
+
+use Closure;
+use Illuminate\Support\Facades\Route;
+use Laravel\Folio\MountPath;
+
+class Loader
+{
+    /**
+     * Invoke the route loader.
+     */
+    public function __invoke(string $uri = '/', MountPath $mountPath, Closure $handler): void
+    {
+        if ($uri === '/') {
+            Route::fallback($handler)
+                ->name('test-folio-custom-loader');
+        } else {
+            Route::get(
+                '/'.trim($uri, '/').'/{uri?}',
+                $handler
+            )->name('test-folio-custom-loader')->where('uri', '.*');
+        }
+    }
+}

--- a/tests/Feature/Fixtures/Loader.php
+++ b/tests/Feature/Fixtures/Loader.php
@@ -11,7 +11,7 @@ class Loader
     /**
      * Invoke the route loader.
      */
-    public function __invoke(string $uri = '/', MountPath $mountPath, Closure $handler): void
+    public function __invoke(string $uri, MountPath $mountPath, Closure $handler): void
     {
         if ($uri === '/') {
             Route::fallback($handler)

--- a/tests/Feature/LoaderTest.php
+++ b/tests/Feature/LoaderTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Laravel\Folio\Folio;
+use Tests\Feature\Fixtures\Loader;
+
+it('can use a custom loader', function(){
+    Folio::route(__DIR__.'/resources/views/pages', loader: new Loader());
+
+    $response = $this->get('/users/Taylor');
+
+    $response->assertOk();
+
+    $this->assertTrue(Route::has('test-folio-custom-loader'));
+});

--- a/tests/Feature/LoaderTest.php
+++ b/tests/Feature/LoaderTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use Laravel\Folio\Folio;
+use Laravel\Folio\MountPath;
 use Tests\Feature\Fixtures\Loader;
 
 it('can use a custom loader', function(){
@@ -12,4 +13,25 @@ it('can use a custom loader', function(){
     $response->assertOk();
 
     $this->assertTrue(Route::has('test-folio-custom-loader'));
+});
+
+it('can use a custom loader as a callback function', function(){
+    Folio::route(__DIR__.'/resources/views/pages', loader: function(string $uri, MountPath $mountPath, Closure $handler){
+
+        if ($uri === '/') {
+            Route::fallback($handler)
+                ->name('test-folio-custom-callback');
+        } else {
+            Route::get(
+                '/'.trim($uri, '/').'/{uri?}',
+                $handler
+            )->name('test-folio-custom-callback')->where('uri', '.*');
+        }
+    });
+
+    $response = $this->get('/users/Taylor');
+
+    $response->assertOk();
+
+    $this->assertTrue(Route::has('test-folio-custom-callback'));
 });


### PR DESCRIPTION
This extracts the `Rout::` calls in `Folio::route()`  to an invokable class, and adds a `loader` parameter to `Folio::route()` where a custom loader can be passed as a callback function or Closure.

- By default the behavior doesn't change so it shouldn't break anything
- The package will still pass `$this->handler($mountPath)` but its use is optional
-  Users are free to call their own custom handler which can be used to extend functionality such as supporting different file extensions, etc.
- Users are free implement their own names and naming patterns for routes