### PR TITLE
[1.x] Adds `Folio::domain`

### DIFF
--- a/src/Folio.php
+++ b/src/Folio.php
@@ -5,12 +5,16 @@ namespace Laravel\Folio;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static static route(string|null $path = null, string|null $uri = '/', array $middleware = [])
+ * @method static PendingRoute route(string|null $path = null, string|null $uri = '/', array $middleware = [])
  * @method static array middlewareFor(string $uri)
  * @method static mixed|null data(string|null $key = null, mixed|null $default = null)
  * @method static \Laravel\Folio\FolioManager renderUsing(\Closure|null $callback = null)
  * @method static array mountPaths()
  * @method static array paths()
+ * @method static \Laravel\Folio\PendingRoute path(string $path)
+ * @method static \Laravel\Folio\PendingRoute uri(string $uri)
+ * @method static \Laravel\Folio\PendingRoute domain(?string $domain)
+ * @method static \Laravel\Folio\PendingRoute middleware(array $middleware)
  *
  * @see \Laravel\Folio\FolioManager
  */

--- a/src/MountPath.php
+++ b/src/MountPath.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Folio;
 
+use Illuminate\Routing\Route;
+
 class MountPath
 {
     /**
@@ -10,13 +12,20 @@ class MountPath
     public PathBasedMiddlewareList $middleware;
 
     /**
+     * The route instance for the mounted path.
+     */
+    protected ?Route $route = null;
+
+    /**
      * Create a new mounted path instance.
      */
     public function __construct(
         public string $path,
         public string $baseUri,
-        array $middleware = [],
+        array $middleware,
+        public ?string $domain,
     ) {
+        $this->path = str_replace('/', DIRECTORY_SEPARATOR, $path);
         $this->middleware = new PathBasedMiddlewareList($middleware);
     }
 

--- a/src/PendingRoute.php
+++ b/src/PendingRoute.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Laravel\Folio;
+
+class PendingRoute
+{
+    /**
+     * Creates a new pending route instance.
+     */
+    public function __construct(
+        protected FolioManager $manager,
+        protected string $path,
+        protected string $uri,
+        protected array $middleware,
+        protected ?string $domain = null,
+    ) {
+    }
+
+    /**
+     * Set the domain for the route.
+     */
+    public function domain(?string $domain): static
+    {
+        $this->domain = $domain;
+
+        return $this;
+    }
+
+    /**
+     * Set the path for the route.
+     */
+    public function path(string $path): static
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    /**
+     * Set the middleware for the route.
+     */
+    public function middleware(array $middleware): static
+    {
+        $this->middleware = $middleware;
+
+        return $this;
+    }
+
+    /**
+     * Set the URI for the route.
+     */
+    public function uri(string $uri): static
+    {
+        $this->uri = $uri;
+
+        return $this;
+    }
+
+    /**
+     * Register the route upon instance destruction.
+     */
+    public function __destruct()
+    {
+        $this->manager->registerRoute(
+            $this->path,
+            $this->uri,
+            $this->middleware,
+            $this->domain,
+        );
+    }
+}

--- a/src/Pipeline/EnsureMatchesDomain.php
+++ b/src/Pipeline/EnsureMatchesDomain.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Laravel\Folio\Pipeline;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Matching\HostValidator;
+use Illuminate\Routing\Route;
+use Laravel\Folio\MountPath;
+
+class EnsureMatchesDomain
+{
+    /**
+     * Create a new pipeline step instance.
+     */
+    public function __construct(protected Request $request, protected MountPath $mountPath)
+    {
+    }
+
+    /**
+     * Invoke the routing pipeline handler.
+     */
+    public function __invoke(State $state, Closure $next): mixed
+    {
+        if ($this->mountPath->domain === null) {
+            return $next($state);
+        }
+
+        $route = (new Route(['GET'], $this->mountPath->baseUri, fn () => null))
+            ->domain($this->mountPath->domain)
+            ->bind($this->request);
+
+        if (! (new HostValidator)->matches($route, $this->request)) {
+            return new Response(status: 404);
+        }
+
+        $state->data = array_merge($state->data, $route->parameters());
+
+        return $next($state);
+    }
+}

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -29,7 +29,7 @@ class RequestHandler
     public function __invoke(Request $request, string $uri): mixed
     {
         $matchedView = (new Router(
-            $this->mountPath->path
+            $this->mountPath
         ))->match($request, $uri) ?? abort(404);
 
         app(Dispatcher::class)->dispatch(new Events\ViewMatched($matchedView, $this->mountPath));

--- a/src/Router.php
+++ b/src/Router.php
@@ -4,8 +4,8 @@ namespace Laravel\Folio;
 
 use Illuminate\Http\Request;
 use Illuminate\Pipeline\Pipeline;
-use Illuminate\Support\Arr;
 use Laravel\Folio\Pipeline\ContinueIterating;
+use Laravel\Folio\Pipeline\EnsureMatchesDomain;
 use Laravel\Folio\Pipeline\EnsureNoDirectoryTraversal;
 use Laravel\Folio\Pipeline\MatchDirectoryIndexViews;
 use Laravel\Folio\Pipeline\MatchedView;
@@ -23,16 +23,10 @@ use Laravel\Folio\Pipeline\TransformModelBindings;
 class Router
 {
     /**
-     * The array of mount paths that contain routable pages.
-     */
-    protected array $mountPaths;
-
-    /**
      * Create a new router instance.
      */
-    public function __construct(array|string $mountPaths)
+    public function __construct(protected MountPath $mountPath)
     {
-        $this->mountPaths = Arr::wrap($mountPaths);
     }
 
     /**
@@ -42,10 +36,8 @@ class Router
     {
         $uri = strlen($uri) > 1 ? trim($uri, '/') : $uri;
 
-        foreach ($this->mountPaths as $mountPath) {
-            if ($view = $this->matchAtPath($mountPath, $request, $uri)) {
-                return $view;
-            }
+        if ($view = $this->matchAtPath($this->mountPath, $request, $uri)) {
+            return $view;
         }
 
         return null;
@@ -54,11 +46,11 @@ class Router
     /**
      * Resolve the given URI via page based routing at the given mount path.
      */
-    protected function matchAtPath(string $mountPath, Request $request, string $uri): ?MatchedView
+    protected function matchAtPath(MountPath $mountPath, Request $request, string $uri): ?MatchedView
     {
         $state = new State(
             uri: $uri,
-            mountPath: $mountPath,
+            mountPath: $mountPath->path,
             segments: explode('/', $uri)
         );
 
@@ -66,6 +58,7 @@ class Router
             $value = (new Pipeline)
                 ->send($state->forIteration($i))
                 ->through([
+                    new EnsureMatchesDomain($request, $mountPath),
                     new EnsureNoDirectoryTraversal,
                     new TransformModelBindings($request),
                     new SetMountPathOnMatchedView,

--- a/tests/Feature/Console/ListCommandTest.php
+++ b/tests/Feature/Console/ListCommandTest.php
@@ -31,6 +31,7 @@ it('may have routes', function () {
           GET       /categories/{category} ......................................................... categories/[.Tests.Feature.Fixtures.Category].blade.php
           GET       /dashboard ......................................................................................................... dashboard.blade.php
           GET       /deleted-podcasts/{podcast} ............................................... deleted-podcasts/[.Tests.Feature.Fixtures.Podcast].blade.php
+          GET       /domain ............................................................................................................... domain.blade.php
           GET       /flights ....................................................................................................... flights/index.blade.php
           GET       /non-routables/{nonRoutable} ............................................. non-routables/[.Tests.Feature.Fixtures.NonRoutable].blade.php
           GET       /podcasts/list ................................................................................................. podcasts/list.blade.php
@@ -40,7 +41,7 @@ it('may have routes', function () {
           GET       /users/nuno ....................................................................................................... users/nuno.blade.php
           GET       /users/{id} ....................................................................................................... users/[id].blade.php
 
-                                                                                                                                         Showing [13] routes
+                                                                                                                                         Showing [14] routes
 
 
         EOF);
@@ -98,12 +99,13 @@ it('has the `--except-path` option', function () {
           GET       /books/{...book}/detail ........................................................ books/[...Tests.Feature.Fixtures.Book]/detail.blade.php
           GET       /categories/{category} ......................................................... categories/[.Tests.Feature.Fixtures.Category].blade.php
           GET       /dashboard ......................................................................................................... dashboard.blade.php
+          GET       /domain ............................................................................................................... domain.blade.php
           GET       /flights ....................................................................................................... flights/index.blade.php
           GET       /non-routables/{nonRoutable} ............................................. non-routables/[.Tests.Feature.Fixtures.NonRoutable].blade.php
           GET       /users/nuno ....................................................................................................... users/nuno.blade.php
           GET       /users/{id} ....................................................................................................... users/[id].blade.php
 
-                                                                                                                                          Showing [8] routes
+                                                                                                                                          Showing [9] routes
 
 
         EOF);
@@ -192,6 +194,7 @@ test('multiple mounted directories', function () {
           GET       /categories/{category} ..................... tests/Feature/resources/views/pages/categories/[.Tests.Feature.Fixtures.Category].blade.php
           GET       /dashboard ..................................................................... tests/Feature/resources/views/pages/dashboard.blade.php
           GET       /deleted-podcasts/{podcast} ........... tests/Feature/resources/views/pages/deleted-podcasts/[.Tests.Feature.Fixtures.Podcast].blade.php
+          GET       /domain ........................................................................... tests/Feature/resources/views/pages/domain.blade.php
           GET       /flights ................................................................... tests/Feature/resources/views/pages/flights/index.blade.php
           GET       /non-routables/{nonRoutable} ......... tests/Feature/resources/views/pages/non-routables/[.Tests.Feature.Fixtures.NonRoutable].blade.php
           GET       /podcasts/list ............................................................. tests/Feature/resources/views/pages/podcasts/list.blade.php
@@ -203,7 +206,7 @@ test('multiple mounted directories', function () {
           GET       /{...user} ................................................................ tests/Feature/resources/views/more-pages/[...User].blade.php
           GET       /{...user}/detail .................................................. tests/Feature/resources/views/more-pages/[...User]/detail.blade.php
 
-                                                                                                                                         Showing [16] routes
+                                                                                                                                         Showing [17] routes
 
 
         EOF);

--- a/tests/Feature/ManagerTest.php
+++ b/tests/Feature/ManagerTest.php
@@ -20,7 +20,7 @@ it('registers routes', function () {
 });
 
 it('registers routes with a custom URI', function (string $uri) {
-    Folio::route(__DIR__.'/resources/views/pages', $uri);
+    Folio::route(__DIR__.'/resources/views/pages')->uri($uri);
 
     $response = $this->get("$uri/users/Taylor");
 
@@ -29,7 +29,7 @@ it('registers routes with a custom URI', function (string $uri) {
 
 it('registers routes with middleware', function () {
     Route::get('login', fn () => 'login')->name('login');
-    Folio::route(__DIR__.'/resources/views/pages', middleware: ['*' => ['auth']]);
+    Folio::route(__DIR__.'/resources/views/pages')->middleware(['*' => ['auth']]);
 
     $response = $this->get('/users/Taylor');
 
@@ -83,3 +83,42 @@ it('doesn\'t fire view matched event on 404', function () {
 
     $events->assertNotDispatched(ViewMatched::class);
 });
+
+it('registers routes with domain', function (?string $domain, string $host, int $status) {
+    Folio::domain($domain)->path(__DIR__.'/resources/views/pages');
+    $response = $this->get("https://$host/users/Taylor");
+
+    $response->assertStatus($status);
+})->with([
+    [null, 'domain.com', 200],
+    [null, 'another-domain.com', 200],
+    [null, 'sub.domain.com', 200],
+    [null, 'another-sub.domain.com', 200],
+
+    ['domain.com', 'domain.com', 200],
+    ['domain.com', 'another-domain.com', 404],
+    ['domain.com', 'sub.domain.com', 404],
+    ['domain.com', 'another-sub.domain.com', 404],
+
+    ['sub.domain.com', 'domain.com', 404],
+    ['sub.domain.com', 'another-domain.com', 404],
+    ['sub.domain.com', 'sub.domain.com', 200],
+    ['sub.domain.com', 'another-sub.domain.com', 404],
+]);
+
+it('registers routes with segments in domain', function (?string $domain, string $host, string $domainValue, string $subDomainValue) {
+    Folio::domain($domain)->path(__DIR__.'/resources/views/pages');
+
+    $response = $this->get("https://$host/domain");
+
+    $response->assertStatus(200)
+        ->assertSee("The domain is: $domainValue.")
+        ->assertSee("The sub-domain is: $subDomainValue.");
+})->with([
+    ['domain.com', 'domain.com', 'none', 'none'],
+    ['sub.domain.com', 'sub.domain.com', 'none', 'none'],
+    ['{domain}.com', 'domain-value.com', 'domain-value', 'none'],
+    ['{subDomain}.domain.com', 'sub-domain-value.domain.com', 'none', 'sub-domain-value'],
+    ['sub.{domain}.com', 'sub.domain-value.com', 'domain-value', 'none'],
+    ['{subDomain}.{domain}.com', 'sub-domain-value.domain-value.com', 'domain-value', 'sub-domain-value'],
+]);

--- a/tests/Feature/resources/views/pages/domain.blade.php
+++ b/tests/Feature/resources/views/pages/domain.blade.php
@@ -1,0 +1,6 @@
+<div>
+    <ul>
+        <li>The domain is: {{ $domain ?? 'none' }}.</li>
+        <li>The sub-domain is: {{ $subDomain ?? 'none'}}.</li>
+    </ul>
+</div>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace Tests;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\View;
 use Laravel\Folio\FolioServiceProvider;
+use Laravel\Folio\MountPath;
 use Laravel\Folio\Router;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 
@@ -59,6 +60,8 @@ abstract class TestCase extends OrchestraTestCase
      */
     protected function router(): Router
     {
-        return new Router([__DIR__.'/tmp/views']);
+        return new Router(
+            new MountPath(__DIR__.'/tmp/views', '/', [], null),
+        );
     }
 }


### PR DESCRIPTION
This pull request adds the Folio::domain method, which allows scoping Folio's routes like so:

```php
Folio::domain('{account}.example.com')->path(resource_path('views/pages'));
```

And, of course, in the example on top, the `$account` is available as a regular view variable. In addition, you can now create routes very similarly to what you do with Laravel's router.

```php
Folio::path(resource_path('views/pages'));
Folio::path(resource_path('views/pages'))->middleware(...);
Folio::domain(...)->path(resource_path('views/pages'))->uri(...);
```