### PR TITLE
[1.x] Add examples to `make:folio` prompt

### DIFF
--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -3,6 +3,7 @@
 namespace Laravel\Folio\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Str;
 use Laravel\Folio\Folio;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -65,6 +66,20 @@ class MakeCommand extends GeneratorCommand
     {
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the Folio page even if the page already exists'],
+        ];
+    }
+
+    /**
+     * Prompt for missing input arguments using the returned questions.
+     *
+     * @return array
+     */
+    protected function promptForMissingArgumentsUsing()
+    {
+        return [
+            'name' => class_exists(Application::class) && version_compare(Application::VERSION, '10.17.0', '>=')
+                ? ['What should the page be named?', 'E.g. users/index, users/[User]']
+                : 'What should the page be named?',
         ];
     }
 }


### PR DESCRIPTION
This PR updates the `make:folio` command to include name examples when prompting for the missing "name" argument:

![image](https://github.com/laravel/folio/assets/4977161/908e4672-cca1-483d-861c-a48ddf1520d5)

The goal of these placeholders is typically to prevent a trip to the docs for those that want to use conventional naming (single vs. plural, suffixes, etc.)

Unlike other `make:*` commands, there are some nuances with the name argument for `make:folio` command, so I chose to include two examples that hopefully demonstrate the "special" behaviour of index routes, nesting, and route model binding. Hopefully, users don't think they can enter comma-separated page names.