### PR TITLE
[1.x] Adds terminable middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "spatie/once": "^3.1"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.0",
+        "orchestra/testbench": "^8.5.10",
         "pestphp/pest": "^2.5",
         "phpstan/phpstan": "^1.10"
     },

--- a/src/FolioManager.php
+++ b/src/FolioManager.php
@@ -90,30 +90,6 @@ class FolioManager
     }
 
     /**
-     * Executes the pending termination callback.
-     */
-    public function terminate(): void
-    {
-        if ($this->terminateUsing) {
-            try {
-                ($this->terminateUsing)($this->app);
-            } finally {
-                $this->terminateUsing = null;
-            }
-        }
-    }
-
-    /**
-     * Specify the callback that should be used when terminating the application.
-     */
-    public function terminateUsing(Closure $callback = null): static
-    {
-        $this->terminateUsing = $callback;
-
-        return $this;
-    }
-
-    /**
      * Get the Folio request handler function.
      */
     protected function handler(MountPath $mountPath): Closure
@@ -164,6 +140,30 @@ class FolioManager
     public function renderUsing(Closure $callback = null): static
     {
         $this->renderUsing = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Execute the pending termination callback.
+     */
+    public function terminate(): void
+    {
+        if ($this->terminateUsing) {
+            try {
+                ($this->terminateUsing)($this->app);
+            } finally {
+                $this->terminateUsing = null;
+            }
+        }
+    }
+
+    /**
+     * Specify the callback that should be used when terminating the application.
+     */
+    public function terminateUsing(Closure $callback = null): static
+    {
+        $this->terminateUsing = $callback;
 
         return $this;
     }

--- a/src/FolioManager.php
+++ b/src/FolioManager.php
@@ -3,6 +3,7 @@
 namespace Laravel\Folio;
 
 use Closure;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Route;
@@ -24,9 +25,21 @@ class FolioManager
     protected ?Closure $renderUsing = null;
 
     /**
+     * The callback that should be used when terminating the manager.
+     */
+    protected ?Closure $terminateUsing = null;
+
+    /**
      * The view that was last matched by Folio.
      */
     protected ?MatchedView $lastMatchedView = null;
+
+    /**
+     * Create a new Folio manager instance.
+     */
+    public function __construct(protected Application $app)
+    {
+    }
 
     /**
      * Register a route to handle page based routing at the given paths.
@@ -77,12 +90,39 @@ class FolioManager
     }
 
     /**
+     * Executes the pending termination callback.
+     */
+    public function terminate(): void
+    {
+        if ($this->terminateUsing) {
+            try {
+                ($this->terminateUsing)($this->app);
+            } finally {
+                $this->terminateUsing = null;
+            }
+        }
+    }
+
+    /**
+     * Specify the callback that should be used when terminating the application.
+     */
+    public function terminateUsing(Closure $callback = null): static
+    {
+        $this->terminateUsing = $callback;
+
+        return $this;
+    }
+
+    /**
      * Get the Folio request handler function.
      */
     protected function handler(MountPath $mountPath): Closure
     {
         return function (Request $request, string $uri = '/') use ($mountPath) {
+            $this->terminateUsing = null;
+
             return (new RequestHandler(
+                $this,
                 $mountPath,
                 $this->renderUsing,
                 fn (MatchedView $matchedView) => $this->lastMatchedView = $matchedView,

--- a/src/FolioServiceProvider.php
+++ b/src/FolioServiceProvider.php
@@ -23,6 +23,8 @@ class FolioServiceProvider extends ServiceProvider
         $this->registerCommands();
 
         $this->registerPublishing();
+
+        $this->registerTerminableCallback();
     }
 
     /**
@@ -42,12 +44,20 @@ class FolioServiceProvider extends ServiceProvider
     /**
      * Register the package's publishable resources.
      */
-    private function registerPublishing(): void
+    protected function registerPublishing(): void
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 __DIR__.'/../stubs/FolioServiceProvider.stub' => app_path('Providers/FolioServiceProvider.php'),
             ], 'folio-provider');
         }
+    }
+
+    /**
+     * Register the package's terminable callback.
+     */
+    private function registerTerminableCallback(): void
+    {
+        $this->app->terminating(fn (FolioManager $manager) => $manager->terminate());
     }
 }

--- a/src/FolioServiceProvider.php
+++ b/src/FolioServiceProvider.php
@@ -21,10 +21,8 @@ class FolioServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->registerCommands();
-
         $this->registerPublishing();
-
-        $this->registerTerminableCallback();
+        $this->registerTerminationCallback();
     }
 
     /**
@@ -54,9 +52,9 @@ class FolioServiceProvider extends ServiceProvider
     }
 
     /**
-     * Register the package's terminable callback.
+     * Register the package's terminating callback.
      */
-    private function registerTerminableCallback(): void
+    protected function registerTerminationCallback(): void
     {
         $this->app->terminating(fn (FolioManager $manager) => $manager->terminate());
     }

--- a/tests/Feature/Fixtures/Dependency.php
+++ b/tests/Feature/Fixtures/Dependency.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Feature\Fixtures;
+
+class Dependency
+{
+    //
+}

--- a/tests/Feature/Fixtures/Http/Middleware/WithTerminableMiddleware.php
+++ b/tests/Feature/Fixtures/Http/Middleware/WithTerminableMiddleware.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature\Fixtures\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class WithTerminableMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $_SERVER['__folio_*_middleware'] = true;
+
+        return $next($request);
+    }
+
+    /**
+     * Handle tasks after the response has been sent to the browser.
+     */
+    public function terminate(Request $request, Response $response): void
+    {
+        $_SERVER['__folio_*_middleware.terminate'] = true;
+    }
+}

--- a/tests/Feature/Fixtures/Http/Middleware/WithTerminableMiddleware.php
+++ b/tests/Feature/Fixtures/Http/Middleware/WithTerminableMiddleware.php
@@ -3,8 +3,10 @@
 namespace Tests\Feature\Fixtures\Http\Middleware;
 
 use Closure;
+use Exception;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Tests\Feature\Fixtures\Dependency;
 
 class WithTerminableMiddleware
 {
@@ -23,8 +25,13 @@ class WithTerminableMiddleware
     /**
      * Handle tasks after the response has been sent to the browser.
      */
-    public function terminate(Request $request, Response $response): void
+    public function terminate(Request $request, Response $response, Dependency $dependency): void
     {
-        $_SERVER['__folio_*_middleware.terminate'] = true;
+        $_SERVER['__folio_*_middleware.terminate']++;
+        $_SERVER['__folio_*_middleware.terminate.dependency'] = $dependency;
+
+        if ($_SERVER['__folio_*_middleware.terminate.should_fail']) {
+            throw new Exception('Terminate failed.');
+        }
     }
 }

--- a/tests/Feature/MiddlewareTest.php
+++ b/tests/Feature/MiddlewareTest.php
@@ -1,14 +1,17 @@
 <?php
 
 use Laravel\Folio\Folio;
+use Tests\Feature\Fixtures\Dependency;
 use Tests\Feature\Fixtures\Http\Middleware\WithTerminableMiddleware;
 
 beforeEach(function () {
     $_SERVER['__folio_*_middleware'] = false;
-    $_SERVER['__folio_*_middleware.terminate'] = false;
     $_SERVER['__folio_users_middleware'] = false;
     $_SERVER['__folio_flights_middleware'] = false;
     $_SERVER['__folio_flights_inline_middleware'] = false;
+    $_SERVER['__folio_*_middleware.terminate'] = 0;
+    $_SERVER['__folio_*_middleware.terminate.should_fail'] = false;
+    $_SERVER['__folio_*_middleware.terminate.dependency'] = false;
 
     Folio::route(__DIR__.'/resources/views/pages', middleware: [
         '*' => [
@@ -48,7 +51,7 @@ test('pages can be rendered and middleware invoked', function () {
 
     $this->assertTrue($_SERVER['__folio_*_middleware']);
     $this->assertTrue($_SERVER['__folio_users_middleware']);
-    $this->assertTrue($_SERVER['__folio_*_middleware.terminate']);
+    $this->assertSame(1, $_SERVER['__folio_*_middleware.terminate']);
 });
 
 test('inline middleware are parsed from page and invoked', function () {
@@ -59,7 +62,7 @@ test('inline middleware are parsed from page and invoked', function () {
     $this->assertTrue($_SERVER['__folio_*_middleware']);
     $this->assertTrue($_SERVER['__folio_flights_middleware']);
     $this->assertTrue($_SERVER['__folio_flights_inline_middleware']);
-    $this->assertTrue($_SERVER['__folio_*_middleware.terminate']);
+    $this->assertSame(1, $_SERVER['__folio_*_middleware.terminate']);
 });
 
 test('middleware can be retrieved for a given uri', function () {
@@ -82,4 +85,54 @@ test('inline middleware can be retrieved for a given uri', function () {
     $this->assertTrue($middleware[2] instanceof Closure);
 
     $this->assertEmpty(Folio::middlewareFor('/missing/1'));
+});
+
+test('terminate middleware is invoked after response is sent', function () {
+    $this->get('/users/Taylor');
+
+    $this->assertSame(1, $_SERVER['__folio_*_middleware.terminate']);
+
+    $this->get('/users/Taylor');
+
+    $this->assertSame(2, $_SERVER['__folio_*_middleware.terminate']);
+
+    $this->get('/non-existent');
+
+    $this->assertSame(2, $_SERVER['__folio_*_middleware.terminate']);
+
+    $this->get('/users/Taylor');
+
+    $this->assertSame(3, $_SERVER['__folio_*_middleware.terminate']);
+});
+
+test('terminate method is invoked using application container', function () {
+    $this->app->bind(Dependency::class, fn () => new Dependency());
+
+    $this->get('/users/Taylor');
+
+    $this->assertInstanceOf(Dependency::class, $firstDependency = $_SERVER['__folio_*_middleware.terminate.dependency']);
+
+    $_SERVER['__folio_*_middleware.terminate.dependency'] = false;
+
+    $this->get('/non-existent');
+
+    $this->assertFalse($_SERVER['__folio_*_middleware.terminate.dependency']);
+
+    $this->get('/users/Taylor');
+
+    $this->assertInstanceOf(Dependency::class, $secondDependency = $_SERVER['__folio_*_middleware.terminate.dependency']);
+
+    $this->assertNotSame($firstDependency, $secondDependency);
+});
+
+test('terminate callback not invoked on non matched routes if previous terminate callback throws an exception', function () {
+    $_SERVER['__folio_*_middleware.terminate.should_fail'] = true;
+
+    expect(fn () => $this->get('/users/Taylor'))->toThrow(Exception::class);
+
+    $this->assertSame(1, $_SERVER['__folio_*_middleware.terminate']);
+
+    $this->get('/non-existent');
+
+    $this->assertSame(1, $_SERVER['__folio_*_middleware.terminate']);
 });

--- a/tests/Feature/MiddlewareTest.php
+++ b/tests/Feature/MiddlewareTest.php
@@ -1,13 +1,19 @@
 <?php
 
 use Laravel\Folio\Folio;
+use Tests\Feature\Fixtures\Http\Middleware\WithTerminableMiddleware;
 
 beforeEach(function () {
+    $_SERVER['__folio_*_middleware'] = false;
+    $_SERVER['__folio_*_middleware.terminate'] = false;
     $_SERVER['__folio_users_middleware'] = false;
     $_SERVER['__folio_flights_middleware'] = false;
     $_SERVER['__folio_flights_inline_middleware'] = false;
 
     Folio::route(__DIR__.'/resources/views/pages', middleware: [
+        '*' => [
+            WithTerminableMiddleware::class,
+        ],
         '/users/*' => [
             function ($request, $next) {
                 $_SERVER['__folio_users_middleware'] = true;
@@ -25,12 +31,24 @@ beforeEach(function () {
     ]);
 });
 
+afterEach(function () {
+    unset(
+        $_SERVER['__folio_*_middleware'],
+        $_SERVER['__folio_*_middleware.terminate'],
+        $_SERVER['__folio_users_middleware'],
+        $_SERVER['__folio_flights_middleware'],
+        $_SERVER['__folio_flights_inline_middleware'],
+    );
+});
+
 test('pages can be rendered and middleware invoked', function () {
     $response = $this->get('/users/Taylor');
 
     $response->assertSee('Hello, Taylor');
 
+    $this->assertTrue($_SERVER['__folio_*_middleware']);
     $this->assertTrue($_SERVER['__folio_users_middleware']);
+    $this->assertTrue($_SERVER['__folio_*_middleware.terminate']);
 });
 
 test('inline middleware are parsed from page and invoked', function () {
@@ -38,15 +56,19 @@ test('inline middleware are parsed from page and invoked', function () {
 
     $response->assertSee('Flight Index');
 
+    $this->assertTrue($_SERVER['__folio_*_middleware']);
     $this->assertTrue($_SERVER['__folio_flights_middleware']);
     $this->assertTrue($_SERVER['__folio_flights_inline_middleware']);
+    $this->assertTrue($_SERVER['__folio_*_middleware.terminate']);
 });
 
 test('middleware can be retrieved for a given uri', function () {
     $middleware = Folio::middlewareFor('/users/1');
 
-    $this->assertCount(1, $middleware);
-    $this->assertTrue($middleware[0] instanceof Closure);
+    $this->assertCount(2, $middleware);
+
+    $this->assertTrue($middleware[0] === WithTerminableMiddleware::class);
+    $this->assertTrue($middleware[1] instanceof Closure);
 
     $this->assertEmpty(Folio::middlewareFor('/missing/1'));
 });
@@ -54,9 +76,10 @@ test('middleware can be retrieved for a given uri', function () {
 test('inline middleware can be retrieved for a given uri', function () {
     $middleware = Folio::middlewareFor('/flights');
 
-    $this->assertCount(2, $middleware);
-    $this->assertTrue($middleware[0] instanceof Closure);
+    $this->assertCount(3, $middleware);
+    $this->assertTrue($middleware[0] === WithTerminableMiddleware::class);
     $this->assertTrue($middleware[1] instanceof Closure);
+    $this->assertTrue($middleware[2] instanceof Closure);
 
     $this->assertEmpty(Folio::middlewareFor('/missing/1'));
 });


### PR DESCRIPTION
This pull requests extends https://github.com/laravel/folio/pull/65 from @crynobone, closes https://github.com/laravel/folio/issues/64, and it adds the possible of having terminable middlewares on Folio.