### PR TITLE
[1.x] Allows multiple Folio mounted paths per URI

### DIFF
--- a/src/FolioManager.php
+++ b/src/FolioManager.php
@@ -95,6 +95,7 @@ class FolioManager
 
             return (new RequestHandler(
                 $this,
+                $mountPaths,
                 $this->renderUsing,
                 fn (MatchedView $matchedView) => $this->lastMatchedView = $matchedView,
             ))($request);

--- a/src/FolioManager.php
+++ b/src/FolioManager.php
@@ -66,6 +66,7 @@ class FolioManager
     public function registerRoute(string $path, string $uri, array $middleware, ?string $domain): void
     {
         $path = realpath($path);
+        $uri = '/'.ltrim($uri, '/');
 
         if (! is_dir($path)) {
             throw new InvalidArgumentException("The given path [{$path}] is not a directory.");

--- a/tests/Feature/ManagerTest.php
+++ b/tests/Feature/ManagerTest.php
@@ -163,10 +163,10 @@ describe('precedence of domains does not matter', function () {
     });
 
     test('declaring "domain.com" last', function () {
-        Folio::domain('another-domain.com')->path(__DIR__.'/resources/views/pages');
-        Folio::domain('domain.com')->path(__DIR__.'/resources/views/pages');
+        Folio::domain('another-domain.com')->uri('/app')->path(__DIR__.'/resources/views/pages');
+        Folio::domain('domain.com')->uri('/app')->path(__DIR__.'/resources/views/pages');
 
-        $response = $this->get('https://domain.com/dashboard');
+        $response = $this->get('https://domain.com/app/dashboard');
 
         $response->assertStatus(200);
     });

--- a/tests/Feature/ManagerTest.php
+++ b/tests/Feature/ManagerTest.php
@@ -220,3 +220,14 @@ test('middleware of non matched domain does not get executed', function () {
 
     expect($_SERVER['__folio_middleware'])->toBe(1);
 });
+
+test('sub domain matching does not get effected by root domain matching', function () {
+    Folio::domain('domain.com')->path(__DIR__.'/resources/views/pages')
+        ->middleware(['*' => [fn () => abort(404)]]);
+
+    Folio::domain('sub.domain.com')->path(__DIR__.'/resources/views/pages');
+
+    $response = $this->get('https://sub.domain.com/dashboard');
+
+    $response->assertStatus(200);
+});

--- a/tests/Feature/ManagerTest.php
+++ b/tests/Feature/ManagerTest.php
@@ -16,7 +16,7 @@ it('registers routes', function () {
 
     $response = $this->get('/users/Taylor');
 
-    $response->assertSee('Hello, Taylor');
+    $response->assertStatus(200)->assertSee('Hello, Taylor');
 });
 
 it('requires a valid path to register routes', function () {
@@ -131,3 +131,71 @@ it('registers routes with segments in domain', function (?string $domain, string
     ['sub.{domain}.com', 'sub.domain-value.com', 'domain-value', 'none'],
     ['{subDomain}.{domain}.com', 'sub-domain-value.domain-value.com', 'domain-value', 'sub-domain-value'],
 ]);
+
+describe('precedence of routes does not matter', function () {
+    test('declaring path that matches first', function () {
+        Folio::path(__DIR__.'/resources/views/even-more-pages');
+        Folio::path(__DIR__.'/resources/views/pages');
+
+        $response = $this->get('/profile');
+
+        $response->assertStatus(200)->assertSee('My profile');
+    });
+
+    test('declaring path that matches last', function () {
+        Folio::path(__DIR__.'/resources/views/pages');
+        Folio::path(__DIR__.'/resources/views/even-more-pages');
+
+        $response = $this->get('/profile');
+
+        $response->assertStatus(200)->assertSee('My profile');
+    });
+});
+
+describe('precedence of domains does not matter', function () {
+    test('declaring "domain.com" first', function () {
+        Folio::domain('domain.com')->path(__DIR__.'/resources/views/pages');
+        Folio::domain('another-domain.com')->path(__DIR__.'/resources/views/pages');
+
+        $response = $this->get('https://domain.com/dashboard');
+
+        $response->assertStatus(200);
+    });
+
+    test('declaring "domain.com" last', function () {
+        Folio::domain('another-domain.com')->path(__DIR__.'/resources/views/pages');
+        Folio::domain('domain.com')->path(__DIR__.'/resources/views/pages');
+
+        $response = $this->get('https://domain.com/dashboard');
+
+        $response->assertStatus(200);
+    });
+});
+
+test('only the middleware of match mount path gets used on duplicate mount paths', function () {
+    $_SERVER['__folio_precedence_middleware'] = 0;
+
+    $middleware = ['*' => [
+        function ($request, $next) {
+            $_SERVER['__folio_precedence_middleware']++;
+
+            return $next($request);
+        },
+    ]];
+
+    Folio::path(__DIR__.'/resources/views/pages')->middleware($middleware);
+    Folio::path(__DIR__.'/resources/views/pages')->middleware($middleware);
+    Folio::path(__DIR__.'/resources/views/pages')->middleware($middleware);
+
+    $response = $this->get('dashboard');
+
+    $response->assertStatus(200);
+
+    expect($_SERVER['__folio_precedence_middleware'])->toBe(1);
+
+    $response = $this->get('dashboard');
+
+    $response->assertStatus(200);
+
+    expect($_SERVER['__folio_precedence_middleware'])->toBe(2);
+});

--- a/tests/Feature/resources/views/even-more-pages/profile.blade.php
+++ b/tests/Feature/resources/views/even-more-pages/profile.blade.php
@@ -1,0 +1,3 @@
+<div>
+    My profile
+</div>


### PR DESCRIPTION
This pull request allows the usage of multiple Folio route registrations per project URI, here is an example of how to use it:

```php
// Domain examples...
Folio::domain('dashboard.example.com')->path('resources/pages/dashboard');
Folio::domain('example.com')->path('resources/pages/landing');

// Middleware examples...
Folio::route('/app')->path('resources/pages/trial-user-pages')
    ->middleware([/** Trial Middleware */]
Folio::route('/app')->path('resources/pages/subscribed-user-pages')
    ->middleware([/** Subscribed Middleware */]
```