### PR TITLE
Custom Folio Extensions

### DIFF
--- a/src/Folio.php
+++ b/src/Folio.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Laravel\Folio\FolioManager renderUsing(\Closure|null $callback = null)
  * @method static array mountPaths()
  * @method static array paths()
- * @method static \Laravel\Folio\PendingRoute route(string|null $path = null, string|null $uri = '/', array $middleware = [])
+ * @method static \Laravel\Folio\PendingRoute route(string|null $path = null, string|null $uri = '/', array $middleware = [], string|null $domain = null, array $extensions = [])
  * @method static \Laravel\Folio\PendingRoute path(string $path)
  * @method static \Laravel\Folio\PendingRoute uri(string $uri)
  * @method static \Laravel\Folio\PendingRoute domain(string $domain)

--- a/src/FolioManager.php
+++ b/src/FolioManager.php
@@ -48,13 +48,15 @@ class FolioManager
      *
      * @throws \InvalidArgumentException
      */
-    public function route(string $path = null, ?string $uri = '/', array $middleware = []): PendingRoute
+    public function route(string $path = null, ?string $uri = '/', array $middleware = [], ?string $domain = null, array $extensions = ['.blade.php']): PendingRoute
     {
         return new PendingRoute(
             $this,
-            $path ? $path : config('view.paths')[0].'/pages',
+            $path ?: config('view.paths')[0].'/pages',
             $uri,
-            $middleware
+            $middleware,
+            $domain,
+            $extensions,
         );
     }
 
@@ -63,7 +65,7 @@ class FolioManager
      *
      * @param  array<string, array<int, string>>  $middleware
      */
-    public function registerRoute(string $path, string $uri, array $middleware, ?string $domain): void
+    public function registerRoute(string $path, string $uri, array $middleware, ?string $domain, ?array $extensions): void
     {
         $path = realpath($path);
         $uri = '/'.ltrim($uri, '/');
@@ -77,6 +79,7 @@ class FolioManager
             $uri,
             $middleware,
             $domain,
+            $extensions,
         );
 
         Route::fallback($this->handler())->name($mountPath->routeName());

--- a/src/MountPath.php
+++ b/src/MountPath.php
@@ -17,6 +17,7 @@ class MountPath
         public string $baseUri,
         array $middleware,
         public ?string $domain,
+        public array $extensions,
     ) {
         $this->path = str_replace('/', DIRECTORY_SEPARATOR, $path);
 

--- a/src/PendingRoute.php
+++ b/src/PendingRoute.php
@@ -8,6 +8,7 @@ class PendingRoute
      * Create a new pending route instance.
      *
      * @param  array<string, array<int, string>>  $middleware
+     * @param  array<string>  $extensions
      */
     public function __construct(
         protected FolioManager $manager,
@@ -15,6 +16,7 @@ class PendingRoute
         protected string $uri,
         protected array $middleware,
         protected ?string $domain = null,
+        protected array $extensions = [],
     ) {
     }
 
@@ -58,6 +60,13 @@ class PendingRoute
         return $this;
     }
 
+    public function extensions(array $extensions): static
+    {
+        $this->extensions = $extensions;
+
+        return $this;
+    }
+
     /**
      * Register the route upon instance destruction.
      */
@@ -68,6 +77,7 @@ class PendingRoute
             $this->uri,
             $this->middleware,
             $this->domain,
+            $this->extensions,
         );
     }
 }

--- a/src/Pipeline/FindsWildcardViews.php
+++ b/src/Pipeline/FindsWildcardViews.php
@@ -10,34 +10,41 @@ trait FindsWildcardViews
     /**
      * Attempt to find a wildcard multi-segment view at the given directory.
      */
-    protected function findWildcardMultiSegmentView(string $directory): ?string
+    protected function findWildcardMultiSegmentView(string $directory, array $extensions = []): ?string
     {
-        return $this->findViewWith($directory, '[...', ']');
+        return $this->findViewWith($directory, '[...', ']', $extensions);
     }
 
     /**
      * Attempt to find a wildcard view at the given directory.
      */
-    protected function findWildcardView(string $directory): ?string
+    protected function findWildcardView(string $directory, array $extensions = []): ?string
     {
-        return $this->findViewWith($directory, '[', ']');
+        return $this->findViewWith($directory, '[', ']', $extensions);
     }
 
     /**
      * Attempt to find a wildcard view at the given directory with the given beginning and ending strings.
      */
-    protected function findViewWith(string $directory, $startsWith, $endsWith): ?string
+    protected function findViewWith(string $directory, $startsWith, $endsWith, array $extensions = []): ?string
     {
         $files = (new Filesystem)->files($directory);
 
-        return collect($files)->first(function ($file) use ($startsWith, $endsWith) {
+        return collect($files)->first(function ($file) use ($startsWith, $endsWith, $extensions) {
             $filename = Str::of($file->getFilename());
 
-            if (! $filename->endsWith('.blade.php')) {
-                return;
+            $extensionFound = false;
+            foreach ($extensions as $extension) {
+                if ($filename->endsWith($extension)) {
+                    $extensionFound = true;
+                    $filename = $filename->before($extension);
+                    break;
+                }
             }
 
-            $filename = $filename->before('.blade.php');
+            if (! $extensionFound) {
+                return;
+            }
 
             return $filename->startsWith($startsWith) &&
                    $filename->endsWith($endsWith);

--- a/src/Pipeline/MatchDirectoryIndexViews.php
+++ b/src/Pipeline/MatchDirectoryIndexViews.php
@@ -7,14 +7,25 @@ use Closure;
 class MatchDirectoryIndexViews
 {
     /**
+     * Create a new pipeline step instance.
+     */
+    public function __construct(protected array $extensions)
+    {
+    }
+
+    /**
      * Invoke the routing pipeline handler.
      */
     public function __invoke(State $state, Closure $next): mixed
     {
-        return $state->onLastUriSegment() &&
-            $state->currentUriSegmentIsDirectory() &&
-            file_exists($path = $state->currentUriSegmentDirectory().'/index.blade.php')
-                ? new MatchedView($path, $state->data)
-                : $next($state);
+        if ($state->onLastUriSegment() &&
+            $state->currentUriSegmentIsDirectory()) {
+            foreach ($this->extensions as $extension) {
+                if (file_exists($path = $state->currentUriSegmentDirectory() . '/index' . $extension)) {
+                    return new MatchedView($path, $state->data);
+                }
+            }
+        }
+        return $next($state);
     }
 }

--- a/src/Pipeline/MatchLiteralViews.php
+++ b/src/Pipeline/MatchLiteralViews.php
@@ -7,13 +7,25 @@ use Closure;
 class MatchLiteralViews
 {
     /**
+     * Create a new pipeline step instance.
+     */
+    public function __construct(protected array $extensions)
+    {
+    }
+
+    /**
      * Invoke the routing pipeline handler.
      */
     public function __invoke(State $state, Closure $next): mixed
     {
-        return $state->onLastUriSegment() &&
-            file_exists($path = $state->currentDirectory().'/'.$state->currentUriSegment().'.blade.php')
-                ? new MatchedView($path, $state->data)
-                : $next($state);
+        if ($state->onLastUriSegment()) {
+            foreach ($this->extensions as $extension) {
+                if (file_exists($path = $state->currentDirectory() . '/' . $state->currentUriSegment() . $extension)) {
+                    return new MatchedView($path, $state->data);
+                }
+            }
+        }
+        return $next($state);
+
     }
 }

--- a/src/Pipeline/MatchRootIndex.php
+++ b/src/Pipeline/MatchRootIndex.php
@@ -6,15 +6,26 @@ use Closure;
 
 class MatchRootIndex
 {
+
+    /**
+     * Create a new pipeline step instance.
+     */
+    public function __construct(protected array $extensions)
+    {
+    }
+
     /**
      * Invoke the routing pipeline handler.
      */
     public function __invoke(State $state, Closure $next): mixed
     {
         if (trim($state->uri) === '/') {
-            return file_exists($path = $state->mountPath.'/index.blade.php')
-                    ? new MatchedView($path, $state->data)
-                    : new StopIterating;
+            foreach ($this->extensions as $extension) {
+                if (file_exists($path = $state->mountPath . '/index' . $extension)) {
+                    return new MatchedView($path, $state->data);
+                }
+            }
+            return new StopIterating;
         }
 
         return $next($state);

--- a/src/Pipeline/MatchWildcardViews.php
+++ b/src/Pipeline/MatchWildcardViews.php
@@ -10,16 +10,27 @@ class MatchWildcardViews
     use FindsWildcardViews;
 
     /**
+     * Create a new pipeline step instance.
+     */
+    public function __construct(protected array $extensions) {
+
+    }
+
+    /**
      * Invoke the routing pipeline handler.
      */
     public function __invoke(State $state, Closure $next): mixed
     {
         if ($state->onLastUriSegment() &&
-            $path = $this->findWildcardView($state->currentDirectory())) {
+            $path = $this->findWildcardView($state->currentDirectory(), $this->extensions)) {
+            $str = Str::of($path);
+
+            foreach ($this->extensions as $extension) {
+                $str->before($extension);
+            }
+
             return new MatchedView($state->currentDirectory().'/'.$path, $state->withData(
-                Str::of($path)
-                    ->before('.blade.php')
-                    ->match('/\[(.*)\]/')->value(),
+                $str->match('/\[(.*)\]/')->value(),
                 $state->currentUriSegment(),
             )->data);
         }

--- a/src/Pipeline/MatchWildcardViewsThatCaptureMultipleSegments.php
+++ b/src/Pipeline/MatchWildcardViewsThatCaptureMultipleSegments.php
@@ -10,15 +10,25 @@ class MatchWildcardViewsThatCaptureMultipleSegments
     use FindsWildcardViews;
 
     /**
+     * Create a new pipeline step instance.
+     */
+    public function __construct(protected array $extensions)
+    {
+    }
+
+    /**
      * Invoke the routing pipeline handler.
      */
     public function __invoke(State $state, Closure $next): mixed
     {
-        if ($path = $this->findWildcardMultiSegmentView($state->currentDirectory())) {
+        if ($path = $this->findWildcardMultiSegmentView($state->currentDirectory(), $this->extensions)) {
+            $str = Str::of($path);
+            foreach ($this->extensions as $extension) {
+                $str->before($extension);
+            }
+
             return new MatchedView($state->currentDirectory().'/'.$path, $state->withData(
-                Str::of($path)
-                    ->before('.blade.php')
-                    ->match('/\[\.\.\.(.*)\]/')->value(),
+                $str->match('/\[\.\.\.(.*)\]/')->value(),
                 array_slice(
                     $state->segments,
                     $state->currentIndex,

--- a/src/Router.php
+++ b/src/Router.php
@@ -62,22 +62,26 @@ class Router
                     new EnsureNoDirectoryTraversal,
                     new TransformModelBindings($request),
                     new SetMountPathOnMatchedView,
-                    new MatchRootIndex,
-                    new MatchDirectoryIndexViews,
-                    new MatchWildcardViewsThatCaptureMultipleSegments,
+                    new MatchRootIndex($this->mountPath->extensions),
+                    new MatchDirectoryIndexViews($this->mountPath->extensions),
+                    new MatchWildcardViewsThatCaptureMultipleSegments($this->mountPath->extensions),
                     new MatchLiteralDirectories,
                     new MatchWildcardDirectories,
-                    new MatchLiteralViews,
-                    new MatchWildcardViews,
+                    new MatchLiteralViews($this->mountPath->extensions),
+                    new MatchWildcardViews($this->mountPath->extensions),
                 ])->then(fn () => new StopIterating);
 
             if ($value instanceof MatchedView) {
                 return $value;
-            } elseif ($value instanceof ContinueIterating) {
+            }
+
+            if ($value instanceof ContinueIterating) {
                 $state = $value->state;
 
                 continue;
-            } elseif ($value instanceof StopIterating) {
+            }
+
+            if ($value instanceof StopIterating) {
                 break;
             }
         }

--- a/tests/Feature/resources/views/pages/markdown/index.md
+++ b/tests/Feature/resources/views/pages/markdown/index.md
@@ -1,0 +1,6 @@
+---
+component: app
+title: Markdown
+---
+
+# Hello world

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -58,10 +58,10 @@ abstract class TestCase extends OrchestraTestCase
     /**
      * Create a new router instance.
      */
-    protected function router(): Router
+    protected function router($extensions = ['.blade.php']): Router
     {
         return new Router(
-            new MountPath(__DIR__.'/tmp/views', '/', [], null),
+            new MountPath(__DIR__.'/tmp/views', '/', [], null, $extensions),
         );
     }
 }


### PR DESCRIPTION
This is a first pass at making #70 possible.

It turns out, the `FolioManager` class has a `$renderUsing` closure. This PR makes it possible for users to tell Folio to actually look at other file extensions other than `.blade.php`. 

It's still unclear whether including a heavier "markdown" extension out of the box is worth it r/e the cost of complexity and maintenance. However, because Folio allows users to pass in a custom Render function, if we allow passing in of extensions, this will give end users the ability to extend this functionality themselves.