### PR TITLE
[1.x] Allow overriding the methods for a route

### DIFF
--- a/src/FolioManager.php
+++ b/src/FolioManager.php
@@ -63,7 +63,7 @@ class FolioManager
      *
      * @param  array<string, array<int, string>>  $middleware
      */
-    public function registerRoute(string $path, string $uri, array $middleware, ?string $domain): void
+    public function registerRoute(string $path, string $uri, array $middleware, ?string $domain, array $allowedMethods): void
     {
         $path = realpath($path);
         $uri = '/'.ltrim($uri, '/');
@@ -79,7 +79,10 @@ class FolioManager
             $domain,
         );
 
-        Route::fallback($this->handler())->name($mountPath->routeName());
+        $placeholder = 'fallbackPlaceholder';
+        Route::addRoute(
+            $allowedMethods, "{{$placeholder}}", $this->handler()
+        )->where($placeholder, '.*')->fallback()->name($mountPath->routeName());
     }
 
     /**

--- a/src/PendingRoute.php
+++ b/src/PendingRoute.php
@@ -15,6 +15,7 @@ class PendingRoute
         protected string $uri,
         protected array $middleware,
         protected ?string $domain = null,
+        protected array $allowedMethods = ['GET'],
     ) {
     }
 
@@ -59,6 +60,16 @@ class PendingRoute
     }
 
     /**
+     * Set the allowed methods for the route.
+     */
+    public function allowedMethods(array $methods): static
+    {
+        $this->allowedMethods = $methods;
+
+        return $this;
+    }
+
+    /**
      * Register the route upon instance destruction.
      */
     public function __destruct()
@@ -68,6 +79,7 @@ class PendingRoute
             $this->uri,
             $this->middleware,
             $this->domain,
+            $this->allowedMethods
         );
     }
 }


### PR DESCRIPTION
What this PR does:
- Copy the `fallback` method body that only allows `GET` requests into the register route method.
- Allows a user to modify the allowed methods.

... That's it.

What does this enable developers to do?

This solves the issue in #72.

In theory, I could create a helper method, say `post`:
```
function post(\Closure $callback)
{
    if (request()->isMethod('post')) {
        return app()->call($callback);
    }
}
```

And then at the top of a view:
```
<?php

post(function (\Illuminate\Http\Request $request) {
    $request->validate([...]);
    // do work here
    return back()->withErrors([...]);
});
?>
```
Pretty neat! It'll allow greater experimentation, and potentially a Laravel Volt-esq developer experience in pure blade. And it takes all of the burden of maintaining something else like this off of Laravel's teams plate.