### PR TITLE
[1.x] Fixes `route:cache` command

### DIFF
--- a/src/FolioManager.php
+++ b/src/FolioManager.php
@@ -87,7 +87,6 @@ class FolioManager
             )->all();
 
             return (new RequestHandler(
-                $this,
                 $mountPaths,
                 $this->renderUsing,
                 fn (MatchedView $matchedView) => $this->lastMatchedView = $matchedView,

--- a/src/FolioManager.php
+++ b/src/FolioManager.php
@@ -3,7 +3,6 @@
 namespace Laravel\Folio;
 
 use Closure;
-use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Route;
@@ -33,13 +32,6 @@ class FolioManager
      * The view that was last matched by Folio.
      */
     protected ?MatchedView $lastMatchedView = null;
-
-    /**
-     * Create a new Folio manager instance.
-     */
-    public function __construct(protected Application $app)
-    {
-    }
 
     /**
      * Register a route to handle page based routing at the given paths.
@@ -148,7 +140,7 @@ class FolioManager
     {
         if ($this->terminateUsing) {
             try {
-                ($this->terminateUsing)($this->app);
+                ($this->terminateUsing)();
             } finally {
                 $this->terminateUsing = null;
             }

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -3,7 +3,6 @@
 namespace Laravel\Folio;
 
 use Closure;
-use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -59,7 +58,7 @@ class RequestHandler
                     ? ($this->renderUsing)($request, $matchedView)
                     : $this->toResponse($matchedView);
 
-                $app = Container::getInstance();
+                $app = app();
 
                 $app->make(FolioManager::class)->terminateUsing(
                     fn () => $middleware->filter(fn ($middleware) => is_string($middleware) && class_exists($middleware) && method_exists($middleware, 'terminate'))

--- a/tests/Feature/Console/RouteCacheCommandTest.php
+++ b/tests/Feature/Console/RouteCacheCommandTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use Laravel\Folio\Folio;
+
+test('routes may be cached', function () {
+    Folio::route(__DIR__.'/../resources/views/pages');
+
+    $command = $this->artisan('route:cache');
+
+    $command->expectsOutputToContain('Routes cached successfully.');
+
+    $command->assertOk();
+});


### PR DESCRIPTION
This pull request addresses https://github.com/laravel/folio/issues/75, and it fixes the `route:cache` command, that previously was giving a "segmentation fault" error while trying to serialize the application's instance.

After being merged, we should release Beta 4 of Folio - with this hotfix.