### PR TITLE
[1.x] Update install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For example, to create a page that is accessible at the `/greeting` URL, just cr
 To get started, install Folio into your project using the Composer package manager:
 
 ```bash
-composer require laravel/folio:^1.0@beta
+composer require laravel/folio:"^1.0@beta"
 ```
 
 After installing Folio, you may execute the `folio:install` Artisan command, which will install Folio's service provider into your application. This service provider registers the directory where Folio will search for routes / pages:


### PR DESCRIPTION
Just wrapping the beta version between quotes to avoid `zsh: no matches found:` it might be related to zsh terminals. but [livewire 3 and volt](https://livewire.laravel.com/docs/volt#installation) have it between quotes so why not this one