### PR TITLE
[1.x] Fixes potencial collision with facade names

### DIFF
--- a/src/Pipeline/PotentiallyBindablePathSegment.php
+++ b/src/Pipeline/PotentiallyBindablePathSegment.php
@@ -3,6 +3,7 @@
 namespace Laravel\Folio\Pipeline;
 
 use BackedEnum;
+use Closure;
 use Exception;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Routing\UrlRoutable;
@@ -10,7 +11,6 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
-use Illuminate\Support\Stringable;
 
 class PotentiallyBindablePathSegment
 {
@@ -18,6 +18,13 @@ class PotentiallyBindablePathSegment
      * The class name of the binding, if any.
      */
     protected ?string $class = null;
+
+    /**
+     * The closure to use to resolve url routable namespaces.
+     *
+     * @var (\Closure(): array<int, string>)|null
+     */
+    protected static ?Closure $resolveUrlRoutableNamespacesUsing = null;
 
     /**
      * Create a new potentially bindable path segment instance.
@@ -127,6 +134,8 @@ class PotentiallyBindablePathSegment
 
     /**
      * Get the class name contained by the bindable segment.
+     *
+     * @throws Exception
      */
     public function class(): string
     {
@@ -134,19 +143,23 @@ class PotentiallyBindablePathSegment
             return $this->class;
         }
 
-        $this->class = (string) Str::of($this->value)
+        $class = Str::of($this->value)
             ->trim('[]')
             ->after('...')
             ->before('-')
             ->before('|')
             ->before(':')
-            ->replace('.', '\\')
-            ->unless(
-                fn (Stringable $s) => $s->contains('\\') || class_exists($s->value()),
-                fn (Stringable $s) => $s->prepend('App\\Models\\')
-            )->trim('\\');
+            ->replace('.', '\\');
 
-        return $this->class;
+        if (! $class->contains('\\')) {
+            $namespaces = value(static::$resolveUrlRoutableNamespacesUsing) ?? ['\\App\\Models', '\\App', ''];
+
+            $namespace = collect($namespaces)->first(fn (string $namespace) => class_exists("$namespace\\$class"), $namespaces[0]);
+
+            $class = $class->prepend($namespace.'\\');
+        }
+
+        return $this->class = $class->trim('\\')->value();
     }
 
     /**
@@ -204,5 +217,15 @@ class PotentiallyBindablePathSegment
     public function trimmed(): string
     {
         return Str::of($this->value)->trim('[]')->after('...')->value();
+    }
+
+    /**
+     * Set the callback to be used to resolve URL routable namespaces.
+     *
+     * @param  (\Closure(): array<int, string>)|null  $callback
+     */
+    public static function resolveUrlRoutableNamespacesUsing(?Closure $callback): void
+    {
+        static::$resolveUrlRoutableNamespacesUsing = $callback;
     }
 }

--- a/src/Pipeline/PotentiallyBindablePathSegment.php
+++ b/src/Pipeline/PotentiallyBindablePathSegment.php
@@ -135,7 +135,7 @@ class PotentiallyBindablePathSegment
     /**
      * Get the class name contained by the bindable segment.
      *
-     * @throws Exception
+     * @throws \Exception
      */
     public function class(): string
     {

--- a/tests/Feature/Console/ListCommandTest.php
+++ b/tests/Feature/Console/ListCommandTest.php
@@ -32,6 +32,7 @@ it('may have routes', function () {
           GET       /dashboard ......................................................................................................... dashboard.blade.php
           GET       /deleted-podcasts/{podcast} ............................................... deleted-podcasts/[.Tests.Feature.Fixtures.Podcast].blade.php
           GET       /domain ............................................................................................................... domain.blade.php
+          GET       /events/{event} ............................................................................................... events/[Event].blade.php
           GET       /flights ....................................................................................................... flights/index.blade.php
           GET       /non-routables/{nonRoutable} ............................................. non-routables/[.Tests.Feature.Fixtures.NonRoutable].blade.php
           GET       /podcasts/list ................................................................................................. podcasts/list.blade.php
@@ -41,7 +42,7 @@ it('may have routes', function () {
           GET       /users/nuno ....................................................................................................... users/nuno.blade.php
           GET       /users/{id} ....................................................................................................... users/[id].blade.php
 
-                                                                                                                                         Showing [14] routes
+                                                                                                                                         Showing [15] routes
 
 
         EOF);
@@ -100,12 +101,13 @@ it('has the `--except-path` option', function () {
           GET       /categories/{category} ......................................................... categories/[.Tests.Feature.Fixtures.Category].blade.php
           GET       /dashboard ......................................................................................................... dashboard.blade.php
           GET       /domain ............................................................................................................... domain.blade.php
+          GET       /events/{event} ............................................................................................... events/[Event].blade.php
           GET       /flights ....................................................................................................... flights/index.blade.php
           GET       /non-routables/{nonRoutable} ............................................. non-routables/[.Tests.Feature.Fixtures.NonRoutable].blade.php
           GET       /users/nuno ....................................................................................................... users/nuno.blade.php
           GET       /users/{id} ....................................................................................................... users/[id].blade.php
 
-                                                                                                                                          Showing [9] routes
+                                                                                                                                         Showing [10] routes
 
 
         EOF);
@@ -195,6 +197,7 @@ test('multiple mounted directories', function () {
           GET       /dashboard ..................................................................... tests/Feature/resources/views/pages/dashboard.blade.php
           GET       /deleted-podcasts/{podcast} ........... tests/Feature/resources/views/pages/deleted-podcasts/[.Tests.Feature.Fixtures.Podcast].blade.php
           GET       /domain ........................................................................... tests/Feature/resources/views/pages/domain.blade.php
+          GET       /events/{event} ........................................................... tests/Feature/resources/views/pages/events/[Event].blade.php
           GET       /flights ................................................................... tests/Feature/resources/views/pages/flights/index.blade.php
           GET       /non-routables/{nonRoutable} ......... tests/Feature/resources/views/pages/non-routables/[.Tests.Feature.Fixtures.NonRoutable].blade.php
           GET       /podcasts/list ............................................................. tests/Feature/resources/views/pages/podcasts/list.blade.php
@@ -206,7 +209,7 @@ test('multiple mounted directories', function () {
           GET       /{...user} ................................................................ tests/Feature/resources/views/more-pages/[...User].blade.php
           GET       /{...user}/detail .................................................. tests/Feature/resources/views/more-pages/[...User]/detail.blade.php
 
-                                                                                                                                         Showing [17] routes
+                                                                                                                                         Showing [18] routes
 
 
         EOF);

--- a/tests/Feature/Fixtures/Event.php
+++ b/tests/Feature/Fixtures/Event.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\Feature\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Event extends Model
+{
+    protected $guarded = [];
+}

--- a/tests/Feature/ModelBindingTest.php
+++ b/tests/Feature/ModelBindingTest.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Support\Facades\Schema;
 use Laravel\Folio\Folio;
+use Laravel\Folio\Pipeline\PotentiallyBindablePathSegment;
+use Tests\Feature\Fixtures\Event;
 use Tests\Feature\Fixtures\Podcast;
 
 beforeEach(function () {
@@ -19,7 +21,16 @@ beforeEach(function () {
         $table->timestamps();
     });
 
+    Schema::create('events', function ($table) {
+        $table->id();
+        $table->timestamps();
+    });
+
     Folio::route(__DIR__.'/resources/views/pages');
+});
+
+afterEach(function () {
+    PotentiallyBindablePathSegment::resolveUrlRoutableNamespacesUsing(null);
 });
 
 test('implicit model bindings are resolved', function () {
@@ -28,6 +39,16 @@ test('implicit model bindings are resolved', function () {
     ]);
 
     $this->get('/podcasts/'.$podcast->id)->assertSee('test-podcast-name');
+});
+
+test('implicit model bindings are resolved even if model base class conflicts with facade name', function () {
+    PotentiallyBindablePathSegment::resolveUrlRoutableNamespacesUsing(function () {
+        return ['\Tests\Feature\Fixtures'];
+    });
+
+    $event = Event::create();
+
+    $this->get('/events/'.$event->id)->assertSee('Tests\Feature\Fixtures\Event: 1.');
 });
 
 test('implicit model bindings are accessible via middleware', function () {

--- a/tests/Feature/resources/views/pages/events/[Event].blade.php
+++ b/tests/Feature/resources/views/pages/events/[Event].blade.php
@@ -1,0 +1,3 @@
+<div>
+    {{ get_class($event) }}: {{ $event->id }}.
+</div>


### PR DESCRIPTION
This pull request fixes https://github.com/laravel/folio/issues/83. When using relative model names, such as Event, we first check if the class exists at `\App\Models` and `\App`; only after that do we fallback to `\Event`.