### PR TITLE
[1.x] Adds route named to `folio:list` command

### DIFF
--- a/src/Console/ListCommand.php
+++ b/src/Console/ListCommand.php
@@ -7,7 +7,9 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Laravel\Folio\FolioManager;
+use Laravel\Folio\FolioRoutes;
 use Laravel\Folio\MountPath;
+use Laravel\Folio\Support\Project;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Finder\Finder;
@@ -28,7 +30,7 @@ class ListCommand extends RouteListCommand
      *
      * @var array<int, string>
      */
-    protected $headers = ['Domain', 'Method', 'URI', 'View'];
+    protected $headers = ['Domain', 'Method', 'URI', 'Name', 'View'];
 
     /**
      * Execute the console command.
@@ -55,7 +57,13 @@ class ListCommand extends RouteListCommand
      */
     protected function formatActionForCli($route): string
     {
-        return $route['view'];
+        $action = $route['view'];
+
+        if (is_string($route['name'])) {
+            $action = $route['name'].' › '.$action;
+        }
+
+        return $action;
     }
 
     /**
@@ -128,7 +136,7 @@ class ListCommand extends RouteListCommand
                         'method' => 'GET',
                         'domain' => $domain,
                         'uri' => $uri === '' ? '/' : $uri,
-                        'name' => '',
+                        'name' => $this->routeName($mountPath, $viewPath),
                         'action' => $action,
                         'view' => $action,
                     ];
@@ -146,6 +154,10 @@ class ListCommand extends RouteListCommand
      */
     protected function filterRoute(array $route): ?array
     {
+        if ($this->option('name') && ! Str::contains((string) $route['name'], $this->option('name'))) {
+            return null;
+        }
+
         if (($this->option('path') && ! Str::contains($route['uri'], $this->option('path')))) {
             return null;
         }
@@ -253,11 +265,25 @@ class ListCommand extends RouteListCommand
     {
         return [
             ['json', null, InputOption::VALUE_NONE, 'Output the route list as JSON'],
+            ['name', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by name'],
             ['domain', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by domain'],
             ['path', null, InputOption::VALUE_OPTIONAL, 'Only show routes matching the given path pattern'],
             ['except-path', null, InputOption::VALUE_OPTIONAL, 'Do not display the routes matching the given path pattern'],
             ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes'],
-            ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (uri, view) to sort by', 'uri'],
+            ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (domain, name, uri, view) to sort by', 'uri'],
         ];
+    }
+
+    /**
+     * Get the route name for the given mount path and view path.
+     */
+    protected function routeName(string $mountPath, string $viewPath): ?string
+    {
+        return collect($this->laravel->make(FolioRoutes::class)->routes())->search(function (array $route) use ($mountPath, $viewPath) {
+            [$routeRelativeMountPath, $routeRelativeViewPath] = $route;
+
+            return $routeRelativeMountPath === Project::relativePathOf($mountPath)
+                && $routeRelativeViewPath === Project::relativePathOf($viewPath);
+        }) ?: null;
     }
 }

--- a/src/FolioRoutes.php
+++ b/src/FolioRoutes.php
@@ -119,16 +119,6 @@ class FolioRoutes
     }
 
     /**
-     * Get all the registered routes.
-     */
-    public function routes(): array
-    {
-        $this->ensureLoaded();
-
-        return $this->routes;
-    }
-
-    /**
      * Get the relative route URL for the given route name and arguments.
      *
      * @param  array<string, mixed>  $parameters
@@ -192,6 +182,16 @@ class FolioRoutes
         }
 
         return $value;
+    }
+
+    /**
+     * Get all of the registered routes.
+     */
+    public function routes(): array
+    {
+        $this->ensureLoaded();
+
+        return $this->routes;
     }
 
     /**

--- a/src/FolioRoutes.php
+++ b/src/FolioRoutes.php
@@ -119,6 +119,16 @@ class FolioRoutes
     }
 
     /**
+     * Get all the registered routes.
+     */
+    public function routes(): array
+    {
+        $this->ensureLoaded();
+
+        return $this->routes;
+    }
+
+    /**
      * Get the relative route URL for the given route name and arguments.
      *
      * @param  array<string, mixed>  $parameters

--- a/src/Options/PageOptions.php
+++ b/src/Options/PageOptions.php
@@ -3,7 +3,6 @@
 namespace Laravel\Folio\Options;
 
 use Closure;
-
 use function Laravel\Folio\middleware;
 use function Laravel\Folio\name;
 use function Laravel\Folio\withTrashed;

--- a/src/Options/PageOptions.php
+++ b/src/Options/PageOptions.php
@@ -3,6 +3,7 @@
 namespace Laravel\Folio\Options;
 
 use Closure;
+
 use function Laravel\Folio\middleware;
 use function Laravel\Folio\name;
 use function Laravel\Folio\withTrashed;

--- a/tests/Feature/Console/ListCommandTest.php
+++ b/tests/Feature/Console/ListCommandTest.php
@@ -29,9 +29,9 @@ it('may have routes', function () {
           GET       /books ........................................................................................................... books/index.blade.php
           GET       /books/{...book}/detail ........................................................ books/[...Tests.Feature.Fixtures.Book]/detail.blade.php
           GET       /categories/{category} ......................................................... categories/[.Tests.Feature.Fixtures.Category].blade.php
-          GET       /dashboard ......................................................................................................... dashboard.blade.php
+          GET       /dashboard ............................................................................................. dashboard › dashboard.blade.php
           GET       /deleted-podcasts/{podcast} ............................................... deleted-podcasts/[.Tests.Feature.Fixtures.Podcast].blade.php
-          GET       /domain ............................................................................................................... domain.blade.php
+          GET       /domain ................................................................................................... my-domain › domain.blade.php
           GET       /events/{event} ............................................................................................... events/[Event].blade.php
           GET       /flights ....................................................................................................... flights/index.blade.php
           GET       /non-routables/{nonRoutable} ............................................. non-routables/[.Tests.Feature.Fixtures.NonRoutable].blade.php
@@ -39,10 +39,10 @@ it('may have routes', function () {
           GET       /podcasts/{podcast} ............................................................... podcasts/[.Tests.Feature.Fixtures.Podcast].blade.php
           GET       /podcasts/{podcast}/comments ....................................... podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/index.blade.php
           GET       /podcasts/{podcast}/comments/{comment:id} podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/[.Tests.Feature.Fixtures.Comment-id].blad…
-          GET       /posts/{lowerCase}/{upperCase}/{podcast}/{user:email}/show ......... posts/[lowerCase]/[UpperCase]/[Podcast]/[User-email]/show.blade.php
-          GET       /users/articles/{user:wrongColumn} ........................................................ users/articles/[User-wrong_column].blade.php
-          GET       /users/nuno ....................................................................................................... users/nuno.blade.php
-          GET       /users/{id} ....................................................................................................... users/[id].blade.php
+          GET       /posts/{lowerCase}/{upperCase}/{podcast}/{user:email}/show posts.show › posts/[lowerCase]/[UpperCase]/[Podcast]/[User-email]/show.bla…
+          GET       /users/articles/{user:wrongColumn} ........................................ user.articles › users/articles/[User-wrong_column].blade.php
+          GET       /users/nuno .......................................................................................... users.nuno › users/nuno.blade.php
+          GET       /users/{id} .......................................................................................... users.show › users/[id].blade.php
 
                                                                                                                                          Showing [17] routes
 
@@ -60,7 +60,7 @@ it('has the `--json` option', function () {
 
     expect($exitCode)->toBe(0)
         ->and($output->fetch())->toStartWith(<<<'EOF'
-        [{"method":"GET","domain":null,"uri":"\/books","view":"books\/index.blade.php"},{"method":"GET","domain":null,"uri":"\/books\/{...book}\/detail
+        [{"method":"GET","domain":null,"uri":"\/books","name":null,"view":"books\/index.blade.php"},{"method":"GET","domain":null,"uri":"\/books\/{...book}\/detail
         EOF);
 });
 
@@ -87,6 +87,26 @@ it('has the `--path` option', function () {
         EOF);
 });
 
+it('has the `--name` option', function () {
+    $output = new BufferedOutput();
+
+    Folio::route(__DIR__.'/../resources/views/pages');
+    $exitCode = Artisan::call('folio:list', [
+        '--name' => 'users',
+    ], $output);
+
+    expect($exitCode)->toBe(0)
+        ->and($output->fetch())->toOutput(<<<'EOF'
+
+          GET       /users/nuno .......................................................................................... users.nuno › users/nuno.blade.php
+          GET       /users/{id} .......................................................................................... users.show › users/[id].blade.php
+
+                                                                                                                                          Showing [2] routes
+
+
+        EOF);
+});
+
 it('has the `--except-path` option', function () {
     $output = new BufferedOutput();
 
@@ -101,15 +121,15 @@ it('has the `--except-path` option', function () {
           GET       /books ........................................................................................................... books/index.blade.php
           GET       /books/{...book}/detail ........................................................ books/[...Tests.Feature.Fixtures.Book]/detail.blade.php
           GET       /categories/{category} ......................................................... categories/[.Tests.Feature.Fixtures.Category].blade.php
-          GET       /dashboard ......................................................................................................... dashboard.blade.php
-          GET       /domain ............................................................................................................... domain.blade.php
+          GET       /dashboard ............................................................................................. dashboard › dashboard.blade.php
+          GET       /domain ................................................................................................... my-domain › domain.blade.php
           GET       /events/{event} ............................................................................................... events/[Event].blade.php
           GET       /flights ....................................................................................................... flights/index.blade.php
           GET       /non-routables/{nonRoutable} ............................................. non-routables/[.Tests.Feature.Fixtures.NonRoutable].blade.php
-          GET       /posts/{lowerCase}/{upperCase}/{podcast}/{user:email}/show ......... posts/[lowerCase]/[UpperCase]/[Podcast]/[User-email]/show.blade.php
-          GET       /users/articles/{user:wrongColumn} ........................................................ users/articles/[User-wrong_column].blade.php
-          GET       /users/nuno ....................................................................................................... users/nuno.blade.php
-          GET       /users/{id} ....................................................................................................... users/[id].blade.php
+          GET       /posts/{lowerCase}/{upperCase}/{podcast}/{user:email}/show posts.show › posts/[lowerCase]/[UpperCase]/[Podcast]/[User-email]/show.bla…
+          GET       /users/articles/{user:wrongColumn} ........................................ user.articles › users/articles/[User-wrong_column].blade.php
+          GET       /users/nuno .......................................................................................... users.nuno › users/nuno.blade.php
+          GET       /users/{id} .......................................................................................... users.show › users/[id].blade.php
 
                                                                                                                                          Showing [12] routes
 
@@ -194,13 +214,13 @@ test('multiple mounted directories', function () {
     expect($exitCode)->toBe(0)
         ->and($output->fetch())->toOutput(<<<'EOF'
 
-          GET       / ............................................................................. tests/Feature/resources/views/more-pages/index.blade.php
+          GET       / .......................................................... more-pages.index › tests/Feature/resources/views/more-pages/index.blade.php
           GET       /books ....................................................................... tests/Feature/resources/views/pages/books/index.blade.php
           GET       /books/{...book}/detail .................... tests/Feature/resources/views/pages/books/[...Tests.Feature.Fixtures.Book]/detail.blade.php
           GET       /categories/{category} ..................... tests/Feature/resources/views/pages/categories/[.Tests.Feature.Fixtures.Category].blade.php
-          GET       /dashboard ..................................................................... tests/Feature/resources/views/pages/dashboard.blade.php
+          GET       /dashboard ......................................................... dashboard › tests/Feature/resources/views/pages/dashboard.blade.php
           GET       /deleted-podcasts/{podcast} ........... tests/Feature/resources/views/pages/deleted-podcasts/[.Tests.Feature.Fixtures.Podcast].blade.php
-          GET       /domain ........................................................................... tests/Feature/resources/views/pages/domain.blade.php
+          GET       /domain ............................................................... my-domain › tests/Feature/resources/views/pages/domain.blade.php
           GET       /events/{event} ........................................................... tests/Feature/resources/views/pages/events/[Event].blade.php
           GET       /flights ................................................................... tests/Feature/resources/views/pages/flights/index.blade.php
           GET       /non-routables/{nonRoutable} ......... tests/Feature/resources/views/pages/non-routables/[.Tests.Feature.Fixtures.NonRoutable].blade.php
@@ -208,12 +228,12 @@ test('multiple mounted directories', function () {
           GET       /podcasts/{podcast} ........................... tests/Feature/resources/views/pages/podcasts/[.Tests.Feature.Fixtures.Podcast].blade.php
           GET       /podcasts/{podcast}/comments ... tests/Feature/resources/views/pages/podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/index.blade.php
           GET       /podcasts/{podcast}/comments/{comment:id} tests/Feature/resources/views/pages/podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/[.Tes…
-          GET       /posts/{lowerCase}/{upperCase}/{podcast}/{user:email}/show tests/Feature/resources/views/pages/posts/[lowerCase]/[UpperCase]/[Podcast]/…
-          GET       /users/articles/{user:wrongColumn} .................... tests/Feature/resources/views/pages/users/articles/[User-wrong_column].blade.php
-          GET       /users/nuno ................................................................... tests/Feature/resources/views/pages/users/nuno.blade.php
-          GET       /users/{id} ................................................................... tests/Feature/resources/views/pages/users/[id].blade.php
+          GET       /posts/{lowerCase}/{upperCase}/{podcast}/{user:email}/show posts.show › tests/Feature/resources/views/pages/posts/[lowerCase]/[UpperC…
+          GET       /users/articles/{user:wrongColumn} .... user.articles › tests/Feature/resources/views/pages/users/articles/[User-wrong_column].blade.php
+          GET       /users/nuno ...................................................... users.nuno › tests/Feature/resources/views/pages/users/nuno.blade.php
+          GET       /users/{id} ...................................................... users.show › tests/Feature/resources/views/pages/users/[id].blade.php
           GET       /{...user} ................................................................ tests/Feature/resources/views/more-pages/[...User].blade.php
-          GET       /{...user}/detail .................................................. tests/Feature/resources/views/more-pages/[...User]/detail.blade.php
+          GET       /{...user}/detail ......................... more-pages.user.detail › tests/Feature/resources/views/more-pages/[...User]/detail.blade.php
 
                                                                                                                                          Showing [20] routes
 


### PR DESCRIPTION
This pull request adds the route `name` to the list `folio:list` command.

<img width="814" alt="Screenshot 2023-08-15 at 19 34 47" src="https://github.com/laravel/folio/assets/5457236/5a145dfe-e080-4520-bce7-42b2ee324202">

In addition, you can now also filter by name using the `--name` option.