### PR TITLE
[1.x] Fixes `route()` base uri, domain, and query parameters

### DIFF
--- a/src/Console/ListCommand.php
+++ b/src/Console/ListCommand.php
@@ -152,7 +152,7 @@ class ListCommand extends RouteListCommand
     protected function routeName(string $mountPath, string $viewPath): ?string
     {
         return collect($this->laravel->make(FolioRoutes::class)->routes())->search(function (array $route) use ($mountPath, $viewPath) {
-            [$routeRelativeMountPath, $routeRelativeViewPath] = $route;
+            ['mountPath' => $routeRelativeMountPath, 'path' => $routeRelativeViewPath] = $route;
 
             return $routeRelativeMountPath === Project::relativePathOf($mountPath)
                 && $routeRelativeViewPath === Project::relativePathOf($viewPath);

--- a/src/FolioRoutes.php
+++ b/src/FolioRoutes.php
@@ -17,6 +17,11 @@ use Symfony\Component\Routing\Exception\RouteNotFoundException;
 class FolioRoutes
 {
     /**
+     * The current version of the persisted routes.
+     */
+    protected static int $version = 1;
+
+    /**
      * Create a new Folio routes instance.
      *
      * @param  array<string, array{string, string}>  $routes
@@ -41,7 +46,10 @@ class FolioRoutes
 
         File::put(
             $this->cachedFolioRoutesPath,
-            '<?php return '.var_export($this->routes, true).';',
+            '<?php return '.var_export([
+                'version' => static::$version,
+                'routes' => $this->routes,
+            ], true).';',
         );
     }
 
@@ -67,9 +75,15 @@ class FolioRoutes
         }
 
         if (File::exists($this->cachedFolioRoutesPath)) {
-            $this->routes = File::getRequire($this->cachedFolioRoutesPath);
+            $cache = File::getRequire($this->cachedFolioRoutesPath);
 
-            return;
+            if (isset($cache['version']) && (int) $cache['version'] === static::$version) {
+                $this->routes = $cache['routes'];
+
+                $this->loaded = true;
+
+                return;
+            }
         }
 
         foreach ($this->manager->mountPaths() as $mountPath) {
@@ -80,8 +94,10 @@ class FolioRoutes
 
                 if ($name = $matchedView->name()) {
                     $this->routes[$name] = [
-                        Project::relativePathOf($matchedView->mountPath),
-                        Project::relativePathOf($matchedView->path),
+                        'mountPath' => Project::relativePathOf($matchedView->mountPath),
+                        'path' => Project::relativePathOf($matchedView->path),
+                        'baseUri' => $mountPath->baseUri,
+                        'domain' => $mountPath->domain,
                     ];
                 }
             }
@@ -102,6 +118,8 @@ class FolioRoutes
 
     /**
      * Get the route URL for the given route name and arguments.
+     *
+     * @thows  \Laravel\Folio\Exceptions\UrlGenerationException
      */
     public function get(string $name, array $arguments, bool $absolute): string
     {
@@ -111,42 +129,61 @@ class FolioRoutes
             throw new RouteNotFoundException("Route [{$name}] not found.");
         }
 
-        [$mountPath, $path] = $this->routes[$name];
+        [
+            'mountPath' => $mountPath,
+            'path' => $path,
+            'baseUri' => $baseUri,
+            'domain' => $domain,
+        ] = $this->routes[$name];
 
-        return with($this->path($mountPath, $path, $arguments), function (string $path) use ($absolute) {
-            return $absolute ? url($path) : $path;
-        });
+        [$path, $remainingArguments] = $this->path($mountPath, $path, $arguments);
+
+        $route = new Route(['GET'], '{__folio_path}', fn () => null);
+
+        $route->name($name)->domain($domain);
+
+        $uri = $baseUri === '/' ? $path : $baseUri.$path;
+
+        try {
+            return url()->toRoute($route, [...$remainingArguments, '__folio_path' => $uri], $absolute);
+        } catch (\Illuminate\Routing\Exceptions\UrlGenerationException $e) {
+            throw new UrlGenerationException(str_replace('{__folio_path}', $uri, $e->getMessage()), $e->getCode(), $e);
+        }
     }
 
     /**
      * Get the relative route URL for the given route name and arguments.
      *
      * @param  array<string, mixed>  $parameters
+     * @return  array{string, array<string, mixed>}
      */
-    protected function path(string $mountPath, string $path, array $parameters): string
+    protected function path(string $mountPath, string $path, array $parameters): array
     {
         $uri = str_replace('.blade.php', '', $path);
 
+        $parameters = collect($parameters);
+        $usedParameters = collect();
+
         $uri = collect(explode('/', $uri))
-            ->map(function (string $segment) use ($parameters, $uri) {
+            ->map(function (string $segment) use ($parameters, $uri, $usedParameters) {
                 if (! Str::startsWith($segment, '[')) {
                     return $segment;
                 }
 
                 $segment = new PotentiallyBindablePathSegment($segment);
 
-                $parameters = collect($parameters)->mapWithKeys(function (mixed $value, string $key) {
-                    return [Str::camel($key) => $value];
-                })->all();
+                $name = $segment->variable();
 
-                if (! isset($parameters[$name = $segment->variable()]) || $parameters[$name] === null) {
-                    throw UrlGenerationException::forMissingParameter($uri, $name);
-                }
+                $value = $parameters->first(function (mixed $value, string $key) use ($name) {
+                    return Str::camel($key) === $name && $value !== null;
+                }, fn () => throw UrlGenerationException::forMissingParameter($uri, $name));
+
+                $usedParameters->put($name, $value);
 
                 return $this->formatParameter(
                     $uri,
                     $name,
-                    $parameters[$name],
+                    $value,
                     $segment->field(),
                     $segment->capturesMultipleSegments()
                 );
@@ -154,7 +191,10 @@ class FolioRoutes
 
         $uri = str_replace(['/index', '/index/'], ['', '/'], $uri);
 
-        return '/'.ltrim(substr($uri, strlen($mountPath)), '/');
+        return [
+            '/'.ltrim(substr($uri, strlen($mountPath)), '/'),
+            $parameters->except($usedParameters->keys()->all())->all(),
+        ];
     }
 
     /**

--- a/src/Options/PageOptions.php
+++ b/src/Options/PageOptions.php
@@ -3,6 +3,7 @@
 namespace Laravel\Folio\Options;
 
 use Closure;
+
 use function Laravel\Folio\middleware;
 use function Laravel\Folio\name;
 use function Laravel\Folio\withTrashed;

--- a/tests/Feature/NameTest.php
+++ b/tests/Feature/NameTest.php
@@ -115,3 +115,23 @@ test('model route binding wrong column', function () {
 test('routes may not have a name', function () {
     route('users.index');
 })->throws(RouteNotFoundException::class, 'Route [users.index] not defined.');
+
+test('custom uri', function () {
+    Folio::uri('/user')->path(__DIR__.'/resources/views/even-more-pages');
+
+    $absoluteRoute = route('profile');
+    $route = route('profile', [], false);
+
+    expect($absoluteRoute)->toBe('http://localhost/user/profile')
+        ->and($route)->toBe('/user/profile');
+});
+
+test('custom domain', function () {
+    Folio::domain('example.com')->uri('/user')->path(__DIR__.'/resources/views/even-more-pages');
+
+    $absoluteRoute = route('profile');
+    $route = route('profile', [], false);
+
+    expect($absoluteRoute)->toBe('http://example.com/user/profile')
+        ->and($route)->toBe('/user/profile');
+});

--- a/tests/Feature/resources/views/even-more-pages/profile.blade.php
+++ b/tests/Feature/resources/views/even-more-pages/profile.blade.php
@@ -1,3 +1,7 @@
 <div>
     My profile
 </div>
+
+<?php
+
+Laravel\Folio\name('profile');

--- a/tests/Unit/FolioRoutesTest.php
+++ b/tests/Unit/FolioRoutesTest.php
@@ -31,13 +31,19 @@ it('may have routes', function (string $name, array $scenario) {
     $arguments = collect($arguments)->map(fn ($argument) => value($argument))->all();
 
     $names = new FolioRoutes(Mockery::mock(FolioManager::class), '', [
-        $name => [$mountPath, $viewPath],
+        $name => [
+            'mountPath' => $mountPath,
+            'path' => $viewPath,
+            'baseUri' => '/',
+            'domain' => null,
+        ],
     ], true);
 
     expect($names->has($name))->toBeTrue()
         ->and($names->get($name, $arguments, false))->toBe($expectedRoute);
 })->with(fn () => collect([
     'podcasts.index' => ['podcasts/index.blade.php', [], '/podcasts'],
+    'podcasts.index-with-query-parameters' => ['podcasts/index.blade.php', ['page' => 1], '/podcasts?page=1'],
     'podcasts.show-by-id' => ['podcasts/[id].blade.php', ['id' => 1], '/podcasts/1'],
     'podcasts.show-by-name' => ['podcasts/[name].blade.php', ['name' => 'Taylor'], '/podcasts/Taylor'],
     'podcasts.show-by-slug' => ['podcasts/[slug].blade.php', ['slug' => 'nuno'], '/podcasts/nuno'],
@@ -49,6 +55,7 @@ it('may have routes', function (string $name, array $scenario) {
     'podcasts.show-by-backed-enum' => ['podcasts/[Category].blade.php', ['category' => Category::Post], '/podcasts/posts'],
     'podcasts.show-by-id-with-nested-page' => ['podcasts/[id]/stats.blade.php', ['id' => 1], '/podcasts/1/stats'],
     'podcasts.stats' => ['podcasts/stats.blade.php', [], '/podcasts/stats'],
+    'podcasts.stats-with-query-parameters' => ['podcasts/stats.blade.php', ['page' => 1, 'lowerCase' => 'lowerCaseKeyValue', 'Upper_case-key' => 'Upper_caseKeyValue'], '/podcasts/stats?page=1&lowerCase=lowerCaseKeyValue&Upper_case-key=Upper_caseKeyValue'],
     'podcasts.many-by-id' => ['podcasts/[...id].blade.php', ['ids' => [1, 2, 3]], '/podcasts/1/2/3'],
     'podcasts.many-by-name' => ['podcasts/[...name].blade.php', ['names' => ['Taylor', 'Nuno']], '/podcasts/Taylor/Nuno'],
     'podcasts.many-by-slug' => ['podcasts/[...slug].blade.php', ['slugs' => ['nuno', 'taylor']], '/podcasts/nuno/taylor'],
@@ -59,6 +66,9 @@ it('may have routes', function (string $name, array $scenario) {
     'podcasts.many-by-model-name-2' => ['podcasts/[...Podcast-name].blade.php', ['podcasts' => fn () => Podcast::all()], '/podcasts/test-podcast-name-1/test-podcast-name-2'],
     'podcasts.many-by-backed-enum' => ['podcasts/[...Category].blade.php', ['categories' => [Category::Post, Category::Video]], '/podcasts/posts/video'],
     'podcasts.many-by-id-with-nested-page' => ['podcasts/[...id]/stats.blade.php', ['ids' => [1, 2, 3]], '/podcasts/1/2/3/stats'],
+    'articles.query-parameter' => ['articles.blade.php', ['page' => 1], '/articles?page=1'],
+    'articles.query-parameters' => ['articles.blade.php', ['page' => 1, 'lowerCase' => 'lowerCaseKeyValue', 'Upper_case-key' => 'Upper_caseKeyValue'], '/articles?page=1&lowerCase=lowerCaseKeyValue&Upper_case-key=Upper_caseKeyValue'],
+    'articles.query-array-parameter' => ['articles.blade.php', ['page' => [1, 2]], '/articles?page%5B0%5D=1&page%5B1%5D=2'],
 ])->map(function (array $value) {
     $mountPath = 'resources/views/pages';
 
@@ -67,9 +77,56 @@ it('may have routes', function (string $name, array $scenario) {
     return [$mountPath, $mountPath.'/'.$viewRelativePath, $arguments, $expectedRoute];
 })->mapWithKeys(fn (array $value, string $key) => [$key => [$key, $value]])->toArray());
 
+it('may have absolute routes', function (string $name, array $scenario) {
+    [$mountPath, $viewPath, $domain, $arguments, $expectedRoute] = $scenario;
+
+    $arguments = collect($arguments)->map(fn ($argument) => value($argument))->all();
+
+    $names = new FolioRoutes(Mockery::mock(FolioManager::class), '', [
+        $name => [
+            'mountPath' => $mountPath,
+            'path' => $viewPath,
+            'baseUri' => '/',
+            'domain' => $domain,
+        ],
+    ], true);
+
+    expect($names->has($name))->toBeTrue()
+        ->and($names->get($name, $arguments, true))->toBe($expectedRoute);
+})->with(fn () => collect([
+    'podcasts.index' => ['podcasts/index.blade.php', 'domain.com', [], 'http://domain.com/podcasts'],
+    'podcasts.show' => ['podcasts/[id].blade.php', 'domain.com', ['id' => 1], 'http://domain.com/podcasts/1'],
+    'podcasts.show-by-account-and-name' => ['podcasts/[name].blade.php', '{account}.domain.com', ['account' => 'taylor', 'name' => 'Taylor'], 'http://taylor.domain.com/podcasts/Taylor'],
+])->map(function (array $value) {
+    $mountPath = 'resources/views/pages';
+
+    [$viewRelativePath, $domain, $arguments, $expectedRoute] = $value;
+
+    return [$mountPath, $mountPath.'/'.$viewRelativePath, $domain, $arguments, $expectedRoute];
+})->mapWithKeys(fn (array $value, string $key) => [$key => [$key, $value]])->toArray());
+
+test('precedence', function () {
+    $names = new FolioRoutes(Mockery::mock(FolioManager::class), '', [
+        'podcasts.show' => [
+            'mountPath' => 'resources/views/pages',
+            'path' => 'resources/views/pages/podcasts/[id].blade.php',
+            'baseUri' => '/',
+            'domain' => null,
+        ],
+    ], true);
+
+    expect(fn () => $names->get('podcasts.show', ['id' => '{name}', 'name' => 'foo'], false))
+        ->toThrow(UrlGenerationException::class, 'Missing required parameter for [Route: podcasts.show] [URI: /podcasts/{name}] [Missing parameter: name].');
+});
+
 it('may not have routes', function () {
     $names = new FolioRoutes(Mockery::mock(FolioManager::class), '', [
-        'podcasts.index' => ['resources/views/pages', 'resources/views/pages/podcasts/index.blade.php'],
+        'podcasts.index' => [
+            'mountPath' => 'resources/views/pages',
+            'path' => 'resources/views/pages/podcasts/index.blade.php',
+            'baseUri' => '/',
+            'domain' => null,
+        ],
     ], true);
 
     expect($names->has('podcasts.show'))->toBeFalse()
@@ -78,7 +135,12 @@ it('may not have routes', function () {
 
 it('can not have missing parameters', function () {
     $names = new FolioRoutes(Mockery::mock(FolioManager::class), '', [
-        'podcasts.show' => ['resources/views/pages', 'resources/views/pages/podcasts/[id].blade.php'],
+        'podcasts.show' => [
+            'mountPath' => 'resources/views/pages',
+            'path' => 'resources/views/pages/podcasts/[id].blade.php',
+            'baseUri' => '/',
+            'domain' => null,
+        ],
     ], true);
 
     expect(fn () => $names->get('podcasts.show', [], false))


### PR DESCRIPTION
This pull request fixes three things when using the `route()` function:

1. 