### PR TITLE
Adds `request()->routeIs(...)` support

### DIFF
--- a/tests/Feature/CurrentRouteTest.php
+++ b/tests/Feature/CurrentRouteTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Laravel\Folio\Folio;
+
+beforeEach(fn () => Folio::route(__DIR__.'/resources/views/another-set-of-pages'));
+
+it('dynamically updates folio is named route', function () {
+    $response = $this->get(route('pens.index'));
+
+    $response
+        ->assertSee('Is pens.index active: true.')
+        ->assertSee('Current route name: pens.index.')
+        ->assertSee('Has pens.index: false.')
+        ->assertSee('Is pens: true.');
+});
+
+it('resets folio is route name after handling request', function () {
+    $this->get(route('pens.index'));
+
+    expect(request()->route()->getName())->toBe('laravel-folio');
+});
+
+it('does not change the route name if there is no name', function () {
+    $response = $this->get('pens/show');
+
+    $response
+        ->assertSee('Is pens.show active: false.')
+        ->assertSee('Current route name: laravel-folio.')
+        ->assertSee('Has pens.show: false.')
+        ->assertSee('Is pens/show: true.');
+});

--- a/tests/Feature/resources/views/another-set-of-pages/pens/index.blade.php
+++ b/tests/Feature/resources/views/another-set-of-pages/pens/index.blade.php
@@ -1,0 +1,14 @@
+<?php
+
+use function Laravel\Folio\name;
+
+name('pens.index'); ?>
+
+<x-app>
+    <ul>
+        <li>Is pens.index active: {{ request()->routeIs('pens.index') ? 'true' : 'false' }}.</li>
+        <li>Current route name: {{ Route::currentRouteName() }}.</li>
+        <li>Has pens.index: {{ Route::has('pens.index') ? 'true' : 'false' }}.</li> <!-- It's a know limitation... -->
+        <li>Is pens: {{ request()->is('pens') ? 'true' : 'false' }}.</li>
+    </ul>
+</x-app>

--- a/tests/Feature/resources/views/another-set-of-pages/pens/show.blade.php
+++ b/tests/Feature/resources/views/another-set-of-pages/pens/show.blade.php
@@ -1,0 +1,8 @@
+<x-app>
+    <ul>
+        <li>Is pens.show active: {{ request()->routeIs('pens.show') ? 'true' : 'false' }}.</li>
+        <li>Current route name: {{ Route::currentRouteName() }}.</li>
+        <li>Has pens.show: {{ Route::has('pens.show') ? 'true' : 'false' }}.</li> <!-- It's a know limitation... -->
+        <li>Is pens/show: {{ request()->is('pens/show') ? 'true' : 'false' }}.</li>
+    </ul>
+</x-app>


### PR DESCRIPTION
This pull request fixes https://github.com/laravel/folio/issues/89, and adds support for the following two scenarios:

1. `Route::currentRouteName` returns the correct Folio's route name when exists, or `laravel-folio` otherwise.
2. Also, when using `request->isRoute(...)` you may know provide the folio route name.