### PR TITLE
Allows access to pipeline via service container

### DIFF
--- a/src/FolioServiceProvider.php
+++ b/src/FolioServiceProvider.php
@@ -18,6 +18,7 @@ class FolioServiceProvider extends ServiceProvider
         $this->app->singleton(FolioManager::class);
         $this->app->singleton(InlineMetadataInterceptor::class);
         $this->app->singleton(FolioRoutes::class);
+        $this->app->bind(Router::class);
 
         $this->app->when(FolioRoutes::class)
             ->needs('$cachedFolioRoutesPath')

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -35,7 +35,7 @@ class RequestHandler
 
             $uri = '/'.ltrim(substr($requestPath, strlen($mountPath->baseUri)), '/');
 
-            if ($matchedView = (new Router($mountPath))->match($request, $uri)) {
+            if ($matchedView = app()->make(Router::class, ['mountPath' =>  $mountPath])->match($request, $uri, $mountPath)) {
                 break;
             }
         }


### PR DESCRIPTION
- This package seems to have settled a bit and become pretty stable.
- This change will make it a lot easier to customize the pipeline in projects which depend on `folio` without maintaining a fork.
   -  This is currently already possible, however doing so requires folding the `RequestHandler` ,`FolioManager`, **and** `Router` into the project
   - I'm doing the above each time I start a new project using this package
   - This reduces code duplication and allows us to submit any future bug fixes or other findings here instead into our own projects
- This won't break any existing installations
#110 
#72 
#70 
#50 
#39 

