### PR TITLE
Allows access to Pipeline via service container

### DIFF
--- a/src/FolioServiceProvider.php
+++ b/src/FolioServiceProvider.php
@@ -18,7 +18,6 @@ class FolioServiceProvider extends ServiceProvider
         $this->app->singleton(FolioManager::class);
         $this->app->singleton(InlineMetadataInterceptor::class);
         $this->app->singleton(FolioRoutes::class);
-        $this->app->bind(Router::class);
 
         $this->app->when(FolioRoutes::class)
             ->needs('$cachedFolioRoutesPath')

--- a/src/FolioServiceProvider.php
+++ b/src/FolioServiceProvider.php
@@ -18,6 +18,7 @@ class FolioServiceProvider extends ServiceProvider
         $this->app->singleton(FolioManager::class);
         $this->app->singleton(InlineMetadataInterceptor::class);
         $this->app->singleton(FolioRoutes::class);
+        $this->app->bind(Router::class);
 
         $this->app->when(FolioRoutes::class)
             ->needs('$cachedFolioRoutesPath')

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -35,7 +35,7 @@ class RequestHandler
 
             $uri = '/'.ltrim(substr($requestPath, strlen($mountPath->baseUri)), '/');
 
-            if ($matchedView = app()->make(Router::class, ['mountPath' =>  $mountPath])->match($request, $uri, $mountPath)) {
+            if ($matchedView = app()->make(Router::class, ['mountPath' =>  $mountPath])->match($request, $uri)) {
                 break;
             }
         }

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -35,7 +35,7 @@ class RequestHandler
 
             $uri = '/'.ltrim(substr($requestPath, strlen($mountPath->baseUri)), '/');
 
-            if ($matchedView = (new Router($mountPath))->match($request, $uri)) {
+            if ($matchedView = app()->make(Router::class, ['mountPath' =>  $mountPath])->match($request, $uri, $mountPath)) {
                 break;
             }
         }


### PR DESCRIPTION
- This package seems to have settled a bit and become pretty stable.
- This change will make it a lot easier to customize the pipeline in projects which depend on `folio` without maintaining a fork.
   -  This is currently already possible, however doing so requires folding the `RequestHandler` ,`FolioManager`, **and** `Router` into the project
   - I'm doing the above each time I start a new project using this package
   - This pr reduces code duplication and allows us to submit any future bug fixes or other findings here instead of into our own projects
- This won't break any existing installations
#110 
#72 
#70 
#50 
#39 

P.S.
Apologies, initially I submitted this through an organization, but `GH` has a [bug](https://github.com/orgs/community/discussions/5634) which prevents allowing edits from maintainers on cross-organization `PR`s

EDIT: (Example Usage)
`AppServiceProvider.php`:
```php

...
use Laravel\Folio\Router as FolioRouter;
use App\Router;
...
    /**
     * Register services.
     */
    public function register(): void
    {
        $this->app->bind(FolioRouter::class, Router::class);
    }
```
```php
...
// app/Router.php
...
class Router extends \Laravel\Folio\Router
{
    /**
     * Resolve the given URI via page based routing at the given mount path.
     */
    protected function matchAtPath(Request $request, string $uri): ?MatchedView
    {
        $state = new State(
            uri: $uri,
            mountPath: $this->mountPath->path,
            segments: explode('/', $uri)
        );

        for ($i = 0; $i < $state->uriSegmentCount(); $i++) {
            $value = (new Pipeline)
                ->send($state->forIteration($i))
                ->through([
                    new EnsureMatchesDomain($request, $this->mountPath),
                    ...
                   // add or change callables as needed
                   ...
                    new MatchWildcardViews,
                ])->then(fn () => new StopIterating);

            if ($value instanceof MatchedView) {
                return $value;
            } elseif ($value instanceof ContinueIterating) {
                $state = $value->state;

                continue;
            } elseif ($value instanceof StopIterating) {
                break;
            }
        }

        return null;
    }}
