### PR TITLE
[1.x] Fixes Wildcard Directories Modifying State for Literal Views in the Base Folder

### DIFF
--- a/src/Pipeline/MatchWildcardDirectories.php
+++ b/src/Pipeline/MatchWildcardDirectories.php
@@ -14,7 +14,7 @@ class MatchWildcardDirectories
     public function __invoke(State $state, Closure $next): mixed
     {
         if ($directory = $this->findWildcardDirectory($state->currentDirectory())) {
-            $state = $state->withData(
+            $currentState = $state->withData(
                 Str::of($directory)
                     ->basename()
                     ->match('/\[(.*)\]/')->value(),
@@ -23,12 +23,12 @@ class MatchWildcardDirectories
                 Str::of($directory)->basename()
             );
 
-            if (! $state->onLastUriSegment()) {
-                return new ContinueIterating($state);
+            if (! $currentState->onLastUriSegment()) {
+                return new ContinueIterating($currentState);
             }
 
-            if (file_exists($path = $state->currentUriSegmentDirectory().'/index.blade.php')) {
-                return new MatchedView($path, $state->data);
+            if (file_exists($path = $currentState->currentUriSegmentDirectory().'/index.blade.php')) {
+                return new MatchedView($path, $currentState->data);
             }
         }
 

--- a/tests/Feature/Console/ListCommandTest.php
+++ b/tests/Feature/Console/ListCommandTest.php
@@ -38,6 +38,7 @@ it('may have routes', function () {
           GET       /podcasts/list ................................................................................................. podcasts/list.blade.php
           GET       /podcasts/{podcast} ............................................................... podcasts/[.Tests.Feature.Fixtures.Podcast].blade.php
           GET       /podcasts/{podcast}/comments ....................................... podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/index.blade.php
+          GET       /podcasts/{podcast}/comments/3 ......................................... podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/3.blade.php
           GET       /podcasts/{podcast}/comments/{comment:id} podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/[.Tests.Feature.Fixtures.Comment-id].blad…
           GET       /posts/{lowerCase}/{upperCase}/{podcast}/{user:email}/show posts.show › posts/[lowerCase]/[UpperCase]/[Podcast]/[User-email]/show.bla…
           GET       /users/articles/{user:wrongColumn} ........................................ user.articles › users/articles/[User-wrong_column].blade.php
@@ -45,7 +46,7 @@ it('may have routes', function () {
           GET       /users/nuno .......................................................................................... users.nuno › users/nuno.blade.php
           GET       /users/{id} .......................................................................................... users.show › users/[id].blade.php
 
-                                                                                                                                         Showing [18] routes
+                                                                                                                                         Showing [19] routes
 
 
         EOF);
@@ -80,9 +81,10 @@ it('has the `--path` option', function () {
           GET       /podcasts/list ................................................................................................. podcasts/list.blade.php
           GET       /podcasts/{podcast} ............................................................... podcasts/[.Tests.Feature.Fixtures.Podcast].blade.php
           GET       /podcasts/{podcast}/comments ....................................... podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/index.blade.php
+          GET       /podcasts/{podcast}/comments/3 ......................................... podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/3.blade.php
           GET       /podcasts/{podcast}/comments/{comment:id} podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/[.Tests.Feature.Fixtures.Comment-id].blad…
 
-                                                                                                                                          Showing [5] routes
+                                                                                                                                          Showing [6] routes
 
 
         EOF);
@@ -171,11 +173,12 @@ it('has the `--sort` option', function () {
 
           GET       /deleted-podcasts/{podcast} ............................................... deleted-podcasts/[.Tests.Feature.Fixtures.Podcast].blade.php
           GET       /podcasts/{podcast} ............................................................... podcasts/[.Tests.Feature.Fixtures.Podcast].blade.php
+          GET       /podcasts/{podcast}/comments/3 ......................................... podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/3.blade.php
           GET       /podcasts/{podcast}/comments/{comment:id} podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/[.Tests.Feature.Fixtures.Comment-id].blad…
           GET       /podcasts/{podcast}/comments ....................................... podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/index.blade.php
           GET       /podcasts/list ................................................................................................. podcasts/list.blade.php
 
-                                                                                                                                          Showing [5] routes
+                                                                                                                                          Showing [6] routes
 
 
         EOF);
@@ -194,12 +197,13 @@ it('has the `--reverse` option', function () {
         ->and($output->fetch())->toOutput(<<<'EOF'
 
           GET       /podcasts/{podcast}/comments/{comment:id} podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/[.Tests.Feature.Fixtures.Comment-id].blad…
+          GET       /podcasts/{podcast}/comments/3 ......................................... podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/3.blade.php
           GET       /podcasts/{podcast}/comments ....................................... podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/index.blade.php
           GET       /podcasts/{podcast} ............................................................... podcasts/[.Tests.Feature.Fixtures.Podcast].blade.php
           GET       /podcasts/list ................................................................................................. podcasts/list.blade.php
           GET       /deleted-podcasts/{podcast} ............................................... deleted-podcasts/[.Tests.Feature.Fixtures.Podcast].blade.php
 
-                                                                                                                                          Showing [5] routes
+                                                                                                                                          Showing [6] routes
 
 
         EOF);
@@ -229,6 +233,7 @@ test('multiple mounted directories', function () {
           GET       /podcasts/list ............................................................. tests/Feature/resources/views/pages/podcasts/list.blade.php
           GET       /podcasts/{podcast} ........................... tests/Feature/resources/views/pages/podcasts/[.Tests.Feature.Fixtures.Podcast].blade.php
           GET       /podcasts/{podcast}/comments ... tests/Feature/resources/views/pages/podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/index.blade.php
+          GET       /podcasts/{podcast}/comments/3 ..... tests/Feature/resources/views/pages/podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/3.blade.php
           GET       /podcasts/{podcast}/comments/{comment:id} tests/Feature/resources/views/pages/podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/[.Tes…
           GET       /posts/{lowerCase}/{upperCase}/{podcast}/{user:email}/show posts.show › tests/Feature/resources/views/pages/posts/[lowerCase]/[UpperC…
           GET       /users/articles/{user:wrongColumn} .... user.articles › tests/Feature/resources/views/pages/users/articles/[User-wrong_column].blade.php
@@ -238,7 +243,7 @@ test('multiple mounted directories', function () {
           GET       /{...user} ................................................................ tests/Feature/resources/views/more-pages/[...User].blade.php
           GET       /{...user}/detail ......................... more-pages.user.detail › tests/Feature/resources/views/more-pages/[...User]/detail.blade.php
 
-                                                                                                                                         Showing [21] routes
+                                                                                                                                         Showing [22] routes
 
 
         EOF);

--- a/tests/Feature/ModelBindingTest.php
+++ b/tests/Feature/ModelBindingTest.php
@@ -118,10 +118,6 @@ test('regular routes may be used if implicit binding can not be resolved', funct
         'content' => 'test-comment-content-2',
     ])->fresh();
 
-    $podcast->comments()->create([
-        'content' => 'test-comment-content-3',
-    ])->fresh();
-
     $this->get('/podcasts/'.$podcast->id.'/comments/2')
         ->assertStatus(200)
         ->assertSee('test-comment-content-2');

--- a/tests/Feature/ModelBindingTest.php
+++ b/tests/Feature/ModelBindingTest.php
@@ -118,13 +118,17 @@ test('regular routes may be used if implicit binding can not be resolved', funct
         'content' => 'test-comment-content-2',
     ])->fresh();
 
-    $podcast->comments()->create([
-        'content' => 'test-comment-content-3',
-    ])->fresh();
-
     $this->get('/podcasts/' . $podcast->id . '/comments/2')
         ->assertStatus(200)
         ->assertSee('test-comment-content-2');
+
+    $this->get('/podcasts/' . $podcast->id . '/comments/3')
+        ->assertStatus(200)
+        ->assertSee('literal-comment');
+
+    $podcast->comments()->create([
+        'content' => 'test-comment-content-3',
+    ])->fresh();
 
     $this->get('/podcasts/' . $podcast->id . '/comments/3')
         ->assertStatus(200)

--- a/tests/Feature/ModelBindingTest.php
+++ b/tests/Feature/ModelBindingTest.php
@@ -94,6 +94,43 @@ test('not found error is thrown if implicit binding can not be resolved', functi
     $this->get('/podcasts/missing-id')->assertNotFound();
 });
 
+test('regular routes may be used if implicit binding can not be resolved', function () {
+    $this->get('/podcasts/list')
+        ->assertStatus(200)
+        ->assertSee('podcast');
+
+    $podcast = Podcast::create([
+        'name' => 'test-podcast-name',
+    ]);
+
+    $this->get('/podcasts/' . $podcast->id . '/comments/1')
+        ->assertNotFound();
+
+    $podcast->comments()->create([
+        'content' => 'test-comment-content-1',
+    ])->fresh();
+
+    $this->get('/podcasts/' . $podcast->id . '/comments/1')
+        ->assertStatus(200)
+        ->assertSee('test-comment-content-1');
+
+    $podcast->comments()->create([
+        'content' => 'test-comment-content-2',
+    ])->fresh();
+
+    $podcast->comments()->create([
+        'content' => 'test-comment-content-3',
+    ])->fresh();
+
+    $this->get('/podcasts/' . $podcast->id . '/comments/2')
+        ->assertStatus(200)
+        ->assertSee('test-comment-content-2');
+
+    $this->get('/podcasts/' . $podcast->id . '/comments/3')
+        ->assertStatus(200)
+        ->assertSee('literal-comment');
+});
+
 test('child implicit bindings are resolved', function () {
     $user = User::create([
         'name' => 'test-name',

--- a/tests/Feature/resources/views/pages/podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/3.blade.php
+++ b/tests/Feature/resources/views/pages/podcasts/[.Tests.Feature.Fixtures.Podcast]/comments/3.blade.php
@@ -1,0 +1,1 @@
+{{ 'literal-comment' }}


### PR DESCRIPTION
Fixes https://github.com/laravel/folio/issues/114.

In this example:

```
- movies/[Movie]/index.blade.php
- movies/[Movie]/characters.blade.php
- movies/index.blade.php
- movies/create.blade.php
```


Since `[Movie]` is a wildcard directory, all requests made to `movies/**` were considered as potentially having a model bind routable segment. So, a request made to `movies/create` was returning a 404 because `create` is not the ID of any movie.

Now, with my pull request, the state is only mutated with model bind routable segments if there are plans to continue iterating. If that is not the case (for example, for literal views like movies/create), we simply move to the next element of the pipeline with the initial state.