### PR TITLE
Return early if directory does not exist when finding wildcard views

### DIFF
--- a/src/Pipeline/FindsWildcardViews.php
+++ b/src/Pipeline/FindsWildcardViews.php
@@ -28,7 +28,11 @@ trait FindsWildcardViews
      */
     protected function findViewWith(string $directory, $startsWith, $endsWith): ?string
     {
-        $files = (new Filesystem)->files($directory);
+        if (!($filesystem = (new Filesystem))->exists($directory)) {
+            return null;
+        }
+
+        $files = $filesystem->files($directory);
 
         return collect($files)->first(function ($file) use ($startsWith, $endsWith) {
             $filename = Str::of($file->getFilename());


### PR DESCRIPTION
Just to be safe it's probably better to go to next matcher or segment and finally return `404` if nothing ever matches, rather than potentially throw `DirectoryNotFoundException` from `symfony/finder/Finder.php`.

This is a `non-breaking` change.

This helps avoid potential future bugs, by helping matchers using the  `FindsWildcardViews` trait to simply match when something matches, and not possibly throw an unexpected exception when it doesn't.

P.s.
There are no doc blocks or type hints mentioning the possible exception.
