### PR TITLE
Allows multi-segment wildcard with empty segments

### DIFF
--- a/src/Pipeline/MatchMultiSegmentWildcardDirectoryIndexViews.php
+++ b/src/Pipeline/MatchMultiSegmentWildcardDirectoryIndexViews.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Laravel\Folio\Pipeline;
+
+use Closure;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+
+class MatchMultiSegmentWildcardDirectoryIndexViews
+{
+    use FindsWildcardViews;
+
+    /**
+     * Invoke the routing pipeline handler.
+     */
+    public function __invoke(State $state, Closure $next): mixed
+    {
+        if (!($filesystem = (new Filesystem()))->exists($state->currentUriSegmentDirectory())) {
+            return $next($state);
+        }
+
+        if($path = $this->findWildcardMultiSegmentView($state->currentUriSegmentDirectory())) {
+            return new MatchedView($state->currentUriSegmentDirectory() . '/' . $path, $state->withData(
+                Str::of($path)
+                    ->before('.blade.php')
+                    ->match('/\[\.\.\.(.*)\]/')->value(),
+                array_slice(
+                    $state->segments,
+                    $state->currentIndex,
+                    $state->uriSegmentCount()
+                )
+            )->data);
+
+        }
+
+        return $next($state);
+    }
+}

--- a/src/Pipeline/MatchRootIndex.php
+++ b/src/Pipeline/MatchRootIndex.php
@@ -14,7 +14,7 @@ class MatchRootIndex
         if (trim($state->uri) === '/') {
             return file_exists($path = $state->mountPath.'/index.blade.php')
                     ? new MatchedView($path, $state->data)
-                    : new StopIterating;
+                    : $next($state);
         }
 
         return $next($state);

--- a/src/Router.php
+++ b/src/Router.php
@@ -11,6 +11,7 @@ use Laravel\Folio\Pipeline\MatchDirectoryIndexViews;
 use Laravel\Folio\Pipeline\MatchedView;
 use Laravel\Folio\Pipeline\MatchLiteralDirectories;
 use Laravel\Folio\Pipeline\MatchLiteralViews;
+use Laravel\Folio\Pipeline\MatchMultiSegmentWildcardDirectoryIndexViews;
 use Laravel\Folio\Pipeline\MatchRootIndex;
 use Laravel\Folio\Pipeline\MatchWildcardDirectories;
 use Laravel\Folio\Pipeline\MatchWildcardViews;
@@ -64,6 +65,7 @@ class Router
                     new SetMountPathOnMatchedView,
                     new MatchRootIndex,
                     new MatchDirectoryIndexViews,
+                    new MatchMultiSegmentWildcardDirectoryIndexViews,
                     new MatchWildcardViewsThatCaptureMultipleSegments,
                     new MatchLiteralDirectories,
                     new MatchWildcardDirectories,


### PR DESCRIPTION
closes #118 

This change allows multi-segment wildcard views like `resources/views/pages/users/[...ids].blade.php` to work in lieu of an `index.blade.php` with the `$ids` array as empty `[]`, which makes the following possible when using `folio`:

```blade
<ul>
    @forelse(\App\Models\User::whereIn('id', $ids)->get() as $user)
       <li>{{ $user->email }}</li>
    @empty
       <li>No users available</li>
    @endforelse
</ul>
```
Also, when browsing to `/users`:

```blade
@json($ids)
<!-- [] -->
```
When browsing to `/users/1/2/3/4`, you get:

```blade
@json($ids)
<!-- [1,2,3,4] -->
```

Incidentally, this also makes the following, more radical, `resources/views/pages/users/[...path].blade.php` example possible:

```blade
<?php

use Illuminate\Contracts\View\View;
use Illuminate\Http\Request;
use Illuminate\Routing\Router;

use function Laravel\Folio\render;

$router = new Router(app('events'), app());

render(function (View $view, $path = []) use ($router) {
    
    $index = function (Request $request) use ($view) {
        // check if request expects json
        if ($request->expectsJson()) {
            return \App\Models\User::all();
        }
        // otherwise, return the view
        return $view->with('title', 'Users');
    };
  
    $router->prefix('/users')->group(function () use ($router, $index) {
        $router->get('', $index);
    });

    return $router->dispatch(request())->send();
}) ?>

<!DOCTYPE html>
<html lang="en">
<head>
    <title>{{ $title }}</title>
    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
</head>
<body>
<div x-data="{
    users: fetch('',{
        headers: {
            'Accept': 'application/json',
        }
    }).then(response => response.json()),
}">
    <ul>
    <template x-for="user in users">
        <li x-text="user.email"></li>
    </template>
    </ul>
</div>
</body>
</html>
```
The above is the start of rapidly prototyped fullstack SPA with `laravel` based routing, `alpinejs` and `folio`!

Note (EDIT):
I don't think it's possible to do anything like this anywhere else so easily or nicely: maintain multiple endpoints that may be required for a view to function using ajax from within the same file as the view itself. If the project grew too large eventually a separate backend could be built for such a project, but, often enough, `YAGNI`.