### PR TITLE
Fixed named routes resolution

### DIFF
--- a/src/FolioServiceProvider.php
+++ b/src/FolioServiceProvider.php
@@ -67,7 +67,7 @@ class FolioServiceProvider extends ServiceProvider
      */
     protected function registerUrlGenerator(): void
     {
-        $this->app->afterResolving(UrlGenerator::class, function ($url) {
+        $this->callAfterResolving(UrlGenerator::class, function ($url) {
             $url->resolveMissingNamedRoutesUsing(function ($name, $parameters, $absolute) {
                 $routes = app(FolioRoutes::class);
 


### PR DESCRIPTION
Updated FolioServiceProvider to use the ServiceProvider function `callAfterResolving` that allows for injection even if UrlGenerator is already resolved then the FolioServiceProvider is loaded.

Fixes #111

I'm not good at writing tests 😔 I don't know how to create a failing test that my PR can then turn green.