### PR TITLE
[1.x] Adds missing URI on `folio:list` command

### DIFF
--- a/src/Console/ListCommand.php
+++ b/src/Console/ListCommand.php
@@ -76,15 +76,16 @@ class ListCommand extends RouteListCommand
         return collect($mountPaths)->map(function (MountPath $mountPath) {
             $views = Finder::create()->in($mountPath->path)->name('*.blade.php')->files()->getIterator();
 
+            $baseUri = rtrim($mountPath->baseUri, '/');
             $domain = $mountPath->domain;
             $mountPath = str_replace(DIRECTORY_SEPARATOR, '/', $mountPath->path);
 
             $path = '/'.ltrim($mountPath, '/');
 
             return collect($views)
-                ->map(function (SplFileInfo $view) use ($domain, $mountPath) {
+                ->map(function (SplFileInfo $view) use ($baseUri, $domain, $mountPath) {
                     $viewPath = str_replace(DIRECTORY_SEPARATOR, '/', $view->getRealPath());
-                    $uri = str_replace($mountPath, '', $viewPath);
+                    $uri = $baseUri.str_replace($mountPath, '', $viewPath);
 
                     if (count($this->laravel->make(FolioManager::class)->mountPaths()) === 1) {
                         $action = str_replace($mountPath.'/', '', $viewPath);

--- a/src/FolioManager.php
+++ b/src/FolioManager.php
@@ -40,7 +40,7 @@ class FolioManager
      *
      * @throws \InvalidArgumentException
      */
-    public function route(string $path = null, ?string $uri = '/', array $middleware = []): PendingRoute
+    public function route(?string $path = null, ?string $uri = '/', array $middleware = []): PendingRoute
     {
         return new PendingRoute(
             $this,
@@ -117,7 +117,7 @@ class FolioManager
     /**
      * Get a piece of data from the route / view that was last matched by Folio.
      */
-    public function data(string $key = null, mixed $default = null): mixed
+    public function data(?string $key = null, mixed $default = null): mixed
     {
         return Arr::get($this->lastMatchedView?->data ?: [], $key, $default);
     }
@@ -125,7 +125,7 @@ class FolioManager
     /**
      * Specify the callback that should be used to render matched views.
      */
-    public function renderUsing(Closure $callback = null): static
+    public function renderUsing(?Closure $callback = null): static
     {
         $this->renderUsing = $callback;
 
@@ -149,7 +149,7 @@ class FolioManager
     /**
      * Specify the callback that should be used when terminating the application.
      */
-    public function terminateUsing(Closure $callback = null): static
+    public function terminateUsing(?Closure $callback = null): static
     {
         $this->terminateUsing = $callback;
 

--- a/src/Pipeline/PotentiallyBindablePathSegment.php
+++ b/src/Pipeline/PotentiallyBindablePathSegment.php
@@ -67,7 +67,7 @@ class PotentiallyBindablePathSegment
      * Resolve the binding or throw a ModelNotFoundException.
      */
     public function resolveOrFail(mixed $value,
-        UrlRoutable $parent = null,
+        ?UrlRoutable $parent = null,
         bool $withTrashed = false): UrlRoutable|BackedEnum
     {
         if (is_null($resolved = $this->resolve($value, $parent, $withTrashed))) {

--- a/tests/Feature/Console/ListCommandTest.php
+++ b/tests/Feature/Console/ListCommandTest.php
@@ -248,3 +248,28 @@ test('multiple mounted directories', function () {
 
         EOF);
 });
+
+it('prefixes URIs', function (string $uri) {
+    $output = new BufferedOutput();
+
+    Folio::path(__DIR__.'/../resources/views/more-pages')->uri($uri);
+
+    $exitCode = Artisan::call('folio:list', [], $output);
+
+    expect($exitCode)->toBe(0)
+        ->and($output->fetch())->toOutput(<<<'EOF'
+
+          GET       /api ................................................................................................ more-pages.index › index.blade.php
+          GET       /api/{...user} ..................................................................................................... [...User].blade.php
+          GET       /api/{...user}/detail .............................................................. more-pages.user.detail › [...User]/detail.blade.php
+
+                                                                                                                                          Showing [3] routes
+
+
+        EOF);
+})->with([
+    'api',
+    '/api',
+    'api/',
+    '/api/',
+]);


### PR DESCRIPTION
This pull request fixes https://github.com/laravel/folio/issues/125, and it adds the missing URI on `folio:list` command.