### PR TITLE
Fix /index route replacement

### DIFF
--- a/src/FolioRoutes.php
+++ b/src/FolioRoutes.php
@@ -192,7 +192,7 @@ class FolioRoutes
                 );
             })->implode('/');
 
-        $uri = str_replace(['/index', '/index/'], ['', '/'], $uri);
+        $uri = preg_replace('#/index/?$#', '/', $uri);
 
         return [
             '/'.ltrim(substr($uri, strlen($mountPath)), '/'),

--- a/src/FolioRoutes.php
+++ b/src/FolioRoutes.php
@@ -192,7 +192,8 @@ class FolioRoutes
                 );
             })->implode('/');
 
-        $uri = preg_replace('#/index/?$#', '/', $uri);
+        $uri = preg_replace('#/index/$#', '/', $uri);
+        $uri = preg_replace('#/index$#', '', $uri);
 
         return [
             '/'.ltrim(substr($uri, strlen($mountPath)), '/'),

--- a/tests/Unit/FolioRoutesTest.php
+++ b/tests/Unit/FolioRoutesTest.php
@@ -47,6 +47,7 @@ it('may have routes', function (string $name, array $scenario) {
     'podcasts.show-by-id' => ['podcasts/[id].blade.php', ['id' => 1], '/podcasts/1'],
     'podcasts.show-by-name' => ['podcasts/[name].blade.php', ['Name' => 'Taylor'], '/podcasts/Taylor'],
     'podcasts.show-by-slug' => ['podcasts/[slug].blade.php', ['slug' => 'nuno'], '/podcasts/nuno'],
+    'podcasts.show-by-slug-that-starts-with-word-index' => ['podcasts/[slug].blade.php', ['slug' => 'index-word-is-the-first'], '/podcasts/index-word-is-the-first'],
     'podcasts.show-by-slug-and-id' => ['podcasts/[slug]/[id].blade.php', ['slug' => 'nuno', 'id' => 1], '/podcasts/nuno/1'],
     'podcasts.show-by-model' => ['podcasts/[Podcast].blade.php', ['podcast' => fn () => Podcast::first()], '/podcasts/1'],
     'podcasts.show-by-model-fqn' => ['podcasts/[.Tests.Feature.Fixtures.Podcast].blade.php', ['podcast' => fn () => Podcast::first()], '/podcasts/1'],


### PR DESCRIPTION
Fixes the issue with /index handling when generating routes. Closes https://github.com/laravel/folio/issues/131.

**Behavior description**
There's an existing behavior to handle index.blade.php files, that replaces index in the url with empty string, to create a proper route.

Let's say I have `/pages/foo/index.blade.php` page with a `name('foo')`.

`route('foo')` would then generate `/foo/index` and replace the `/index` part to an empty string.

**The bug**
Let's say I have `/pages/foo/[slug].blade.php` page with a `name('foo')`.

And my slug accidentally start with word "index".

`route('foo', ['slug' => 'index-shows-growth'])` **should** then generate `/foo/index-shows-growth` 

**But**, because of the rule above, it'll generate `/foo-shows-growth` with `/index` replaced out.

**The solution**
Change replacing function to regex and add an end of line to the end of the pattern.

That way we still replace `/index` to empty string, but won't replace slugs that start with `/index`.