### PR TITLE
[1.x] Fixes routing when slug starts with `index`

### DIFF
--- a/src/FolioRoutes.php
+++ b/src/FolioRoutes.php
@@ -192,7 +192,11 @@ class FolioRoutes
                 );
             })->implode('/');
 
-        $uri = str_replace(['/index', '/index/'], ['', '/'], $uri);
+        $uri = match(true) {
+            str_ends_with($uri, '/index') => substr($uri, 0, -6),
+            str_ends_with($uri, '/index/') => substr($uri, 0, -7),
+            default => $uri,
+        };
 
         return [
             '/'.ltrim(substr($uri, strlen($mountPath)), '/'),

--- a/tests/Unit/FolioRoutesTest.php
+++ b/tests/Unit/FolioRoutesTest.php
@@ -42,6 +42,9 @@ it('may have routes', function (string $name, array $scenario) {
     expect($names->has($name))->toBeTrue()
         ->and($names->get($name, $arguments, false))->toBe($expectedRoute);
 })->with(fn () => collect([
+    'index' => ['index.blade.php', [], '/'],
+    'index.index.index' => ['index/index/index.blade.php', [], '/index/index'],
+    'index.show-by-slug' => ['index/[slug].blade.php', ['slug' => 'index-directory'], '/index/index-directory'],
     'podcasts.index' => ['podcasts/index.blade.php', [], '/podcasts'],
     'podcasts.index-with-query-parameters' => ['podcasts/index.blade.php', ['page' => 1], '/podcasts?page=1'],
     'podcasts.show-by-id' => ['podcasts/[id].blade.php', ['id' => 1], '/podcasts/1'],


### PR DESCRIPTION
This pull request fixes routing when slug starts with `index`.

Fixes https://github.com/laravel/folio/issues/131, and replaces https://github.com/laravel/folio/pull/132.