### PR TITLE
Namespace make command

### DIFF
--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -9,7 +9,7 @@ use Laravel\Folio\Folio;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'make:folio')]
+#[AsCommand(name: 'folio:page')]
 class MakeCommand extends GeneratorCommand
 {
     /**
@@ -17,7 +17,7 @@ class MakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $name = 'make:folio';
+    protected $name = 'folio:page';
 
     /**
      * The console command description.
@@ -32,6 +32,13 @@ class MakeCommand extends GeneratorCommand
      * @var string
      */
     protected $type = 'Page';
+
+    /**
+     * The console command name aliases.
+     *
+     * @var array<int, string>
+     */
+    protected $aliases = ['make:folio'];
 
     /**
      * Get the destination view path.


### PR DESCRIPTION
Namespaces folio's make command.

It is currently inconsistent with the rest of the ecosystem.

```
make:folio
pennant:feature
dusk:make
dusk:page
dusk:component
```

`make:folio` => `folio:page`

```
folio:page
pennant:feature
dusk:make
dusk:page
dusk:component
```

`folio:make` is also an option, but I liked that the command still expresses what it makes, i.e., a page.