### PR TITLE
[1.x] Adds stub option to make command

### DIFF
--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Folio\Console;
 
-use Illuminate\Console\Concerns\GetStubOption
+use Illuminate\Console\Concerns\GetStubOption;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Str;

--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -13,6 +13,8 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'make:folio')]
 class MakeCommand extends GeneratorCommand
 {
+    use GetStubOption;
+    
     /**
      * The name and signature of the console command.
      *

--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Folio\Console;
 
+use Illuminate\Console\Concerns\GetStubOption
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Str;

--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -66,6 +66,7 @@ class MakeCommand extends GeneratorCommand
     {
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the Folio page even if the page already exists'],
+            ['stub', 's', InputOption::VALUE_OPTIONAL, 'The stub file to use'],
         ];
     }
 


### PR DESCRIPTION
Depends on https://github.com/laravel/framework/pull/50709

## Usage:

###  Supports passing either a named stub, or full path to a stub as an option

```bash
php artisan make:folio "todos/index" --stub="folio-index"
```
will find and use `base_path('stubs/folio-index.stub')` if it exists.

```bash
php artisan make:folio "todos/index" \
  --stub="/home/taylor/stubs/talks/laracon/2024/us/folio/todos-index.stub"
```

will find and use `/home/taylor/stubs/talks/laracon/2024/us/folio/todos-index.stub` if it exists.

If it cannot find a stub under the name or path, it will ignore the option altogether and behave as it always has.