### PR TITLE
Fix route priority: literal views now take precedence over wildcard directories

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -64,8 +64,8 @@ class Router
                     new MatchDirectoryIndexViews,
                     new MatchWildcardViewsThatCaptureMultipleSegments,
                     new MatchLiteralDirectories,
-                    new MatchWildcardDirectories,
                     new MatchLiteralViews,
+                    new MatchWildcardDirectories,
                     new MatchWildcardViews,
                 ])->then(fn () => new StopIterating);
 


### PR DESCRIPTION
### Problem
When both a literal view and a wildcard directory exist for the same route segment, wildcard directories are matched first, causing unexpected routing behavior.

**Example issue:**
```
/user/create.blade.php         # Literal view  
/user/[id]/index.blade.php     # Wildcard directory
```

Visiting `/user/create` incorrectly matches `/user/[id]/` (treating "create" as `[id]`) instead of `/user/create.blade.php`.

### Real-World Impact
This breaks common CRUD patterns where developers expect:
- `/user/create` → Create form  
- `/user/[id]` → User profile
- `/user/[id]/edit` → Edit form

Currently forces non-intuitive workarounds or file restructuring.

### Solution
Reorder pipeline in `Router.php` to prioritize `MatchLiteralViews` before `MatchWildcardDirectories`.

**Change:** Just swap two lines in the routing pipeline to follow specificity-first matching.