### PR TITLE
Add ability to call route helper function with a model as argument

### DIFF
--- a/tests/Feature/NameTest.php
+++ b/tests/Feature/NameTest.php
@@ -135,3 +135,25 @@ test('custom domain', function () {
     expect($absoluteRoute)->toBe('http://example.com/user/profile')
         ->and($route)->toBe('/user/profile');
 });
+
+test('can write routes with a model as argument', function() {
+
+    // check single model as parameter
+    $user = User::first();
+    $user->wrong_column = 'wrong_column_value';
+    $generatedUrl = route('user.articles', $user, false);
+    $expectedUrl = "/users/articles/wrong_column_value";
+
+    expect( $generatedUrl )->toBe($expectedUrl);
+});
+
+test('can write routes with multiple models as arguments', function() {
+    $user = User::first();
+    $podcast = Podcast::first();
+
+    // check multiple models as parameters
+    $generatedUrl = route('posts.show', [ $podcast, $user, 'lowerCase' => 'lowerCaseValue', 'upperCase' => 'UpperCaseValue' ], false);
+    $expectedUrl = "/posts/lowerCaseValue/UpperCaseValue/{$podcast->id}/{$user->email}/show";
+
+    expect($generatedUrl)->toBe($expectedUrl);
+});


### PR DESCRIPTION
Laravel allows to write routes by calling route method with a single model as argument

`route( 'users.show', $user );`

or 

`route( 'users.podcasts.detail', [ $user, $podcast ] );`

Hoping to fix #148 the good way… this time ;)


Regards,
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
