### PR TITLE
Fix route() helper to accept positional parameters

### DIFF
--- a/src/FolioRoutes.php
+++ b/src/FolioRoutes.php
@@ -161,6 +161,8 @@ class FolioRoutes
     {
         $uri = str_replace('.blade.php', '', $path);
 
+        $parameters = $this->resolveImplicitParameters($uri, $parameters);
+
         [$parameters, $usedParameters] = [collect($parameters), collect()];
 
         $uri = collect(explode('/', $uri))
@@ -202,6 +204,37 @@ class FolioRoutes
             '/'.ltrim(substr($uri, strlen($mountPath)), '/'),
             $parameters->except($usedParameters->all())->all(),
         ];
+    }
+
+    /**
+     * Resolve numerically-indexed parameters to named parameters
+     * based on the path segments' variable names.
+     *
+     * @param  array<int|string, mixed>  $parameters
+     * @return array<string, mixed>
+     */
+    protected function resolveImplicitParameters(string $uri, array $parameters): array
+    {
+        if (empty($parameters) || ! array_is_list($parameters)) {
+            return $parameters;
+        }
+
+        $segmentNames = collect(explode('/', $uri))
+            ->filter(fn (string $segment) => Str::startsWith($segment, '['))
+            ->map(fn (string $segment) => (new PotentiallyBindablePathSegment($segment))->variable())
+            ->values();
+
+        $resolved = [];
+
+        foreach ($parameters as $index => $value) {
+            if ($segmentNames->has($index)) {
+                $resolved[$segmentNames->get($index)] = $value;
+            } else {
+                $resolved[$index] = $value;
+            }
+        }
+
+        return $resolved;
     }
 
     /**

--- a/tests/Unit/FolioRoutesTest.php
+++ b/tests/Unit/FolioRoutesTest.php
@@ -170,6 +170,34 @@ test('missing parameters', function (string $name, array $scenario) {
     return [$mountPath, $mountPath.'/'.$viewRelativePath, $domain, $arguments, $expectedExpectationMessage];
 })->mapWithKeys(fn (array $value, string $key) => [$key => [$key, $value]])->toArray());
 
+it('may resolve positional parameters to named parameters', function (string $name, array $scenario) {
+    [$mountPath, $viewPath, $arguments, $expectedRoute] = $scenario;
+
+    $arguments = collect($arguments)->map(fn ($argument) => value($argument))->all();
+
+    $names = new FolioRoutes(Mockery::mock(FolioManager::class), '', [
+        $name => [
+            'mountPath' => $mountPath,
+            'path' => $viewPath,
+            'baseUri' => '/',
+            'domain' => null,
+        ],
+    ], true);
+
+    expect($names->has($name))->toBeTrue()
+        ->and($names->get($name, $arguments, false))->toBe($expectedRoute);
+})->with(fn () => collect([
+    'podcasts.show-by-id' => ['podcasts/[id].blade.php', [1], '/podcasts/1'],
+    'podcasts.show-by-model' => ['podcasts/[Podcast].blade.php', [fn () => Podcast::first()], '/podcasts/1'],
+    'podcasts.show-by-slug-and-id' => ['podcasts/[slug]/[id].blade.php', ['nuno', 1], '/podcasts/nuno/1'],
+])->map(function (array $value) {
+    $mountPath = 'resources/views/pages';
+
+    [$viewRelativePath, $arguments, $expectedRoute] = $value;
+
+    return [$mountPath, $mountPath.'/'.$viewRelativePath, $arguments, $expectedRoute];
+})->mapWithKeys(fn (array $value, string $key) => [$key => [$key, $value]])->toArray());
+
 it('may not have routes', function () {
     $names = new FolioRoutes(Mockery::mock(FolioManager::class), '', [
         'podcasts.index' => [


### PR DESCRIPTION
## Summary
- The `route()` helper for Folio routes required named parameters (`['user' => $user]`), unlike traditional Laravel routes which accept positional parameters (`$user`)
- This fix adds `resolveImplicitParameters()` which maps numerically-indexed parameters to named parameters based on the order of path segment variables
- Now `route('folio.user', $user)` works the same as `route('folio.user', ['user' => $user])`, consistent with traditional Laravel route behavior

Fixes #148

## Test plan
- [x] Added test: positional parameter with simple value (e.g. `[1]` for `[id]` segment)
- [x] Added test: positional parameter with model binding
- [x] Added test: multiple positional parameters
- [x] All 46 FolioRoutes unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)