### PR TITLE
Fix Blade directive syntax for route helpers

### DIFF
--- a/resources/boost/skills/folio-routing/SKILL.blade.php
+++ b/resources/boost/skills/folio-routing/SKILL.blade.php
@@ -48,8 +48,8 @@ Always create new `folio` pages and routes using `{{ $assist->artisanCommand('fo
 
 A Folio page has up to two distinct code blocks above the Blade template:
 
-1. Metadata block (required for `name`/`middleware`/`render`/`withTrashed`) — a raw `<?php ... ?>` block at the very top.
-2. View-data block (optional) — a `@php ... @endphp` Blade directive below the metadata block, for per-request data loading.
+1. Metadata block (required for `name`/`middleware`/`render`/`withTrashed`) — a raw `<?php ?>` block at the very top.
+2. View-data block (optional) — a `@php @endphp` Blade directive below the metadata block, for per-request data loading.
 
 @boostsnippet("Folio Page Skeleton", "blade")
 <?php
@@ -114,7 +114,7 @@ The array key must match the filename token: for `pages/posts/[Post].blade.php` 
 <a href="{{ route('posts.show', $post) }}">{{ $post->title }}</a>
 @endboostsnippet
 
-For routes without parameters, the helper works as usual: `{{ route('posts.index') }}`.
+For routes without parameters, the helper works as usual: `@{{ route('posts.index') }}`.
 
 ## Middleware
 
@@ -171,7 +171,7 @@ render(function (View $view, Post $post) {
 - Using `[id]` or `[user]` when model binding requires `[User]`
 - Not following existing naming conventions when creating pages
 - Creating routes manually in `routes/web.php` instead of using Folio's file-based routing
-- Wrapping `name()`, `middleware()`, `render()`, or `withTrashed()` in a `@php ... @endphp` Blade directive. Folio's scanner only reads raw `<?php ... ?>` blocks, so those calls are silently ignored — the named route is never registered, middleware is never applied, and `folio:list` will not show the expected route attributes.
+- Wrapping `name()`, `middleware()`, `render()`, or `withTrashed()` in a `@php @endphp` Blade directive. Folio's scanner only reads raw `<?php ?>` blocks, so those calls are silently ignored — the named route is never registered, middleware is never applied, and `folio:list` will not show the expected route attributes.
 - Calling `route('page.name', $model)` with a single model instance. Folio's URL generator requires a keyed array: `route('page.name', ['model' => $model])`. Passing a model directly throws `TypeError` at render time.
 
 ### Folio 404 Debug Checklist


### PR DESCRIPTION
Running `php artisan boost:update --ansi` breaks if the Laravel project has Folio installed. This is because Boost parses the PHP syntax and attempts to compile it.

Removing the `...` in `<?php ... ?>` and `@php ... @endphp` fixes the first problem referenced in #161.

However, another problem emerges with

```
For routes without parameters, the helper works as usual: `{{ route('posts.index') }}`.
```

To fix this, simply escape the curly braces:

```
For routes without parameters, the helper works as usual: `@{{ route('posts.index') }}`.
```

Issue: https://github.com/laravel/folio/issues/161

Comment on Issue: https://github.com/laravel/folio/issues/161#issuecomment-4328470813

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
