### PR TITLE
Fixed route caching breaking Folio

### DIFF
--- a/src/FolioManager.php
+++ b/src/FolioManager.php
@@ -71,27 +71,25 @@ class FolioManager
             $domain,
         );
 
-        Route::fallback($this->handler())->name('laravel-folio');
+        Route::fallback([self::class, 'handle'])->name('laravel-folio');
     }
 
     /**
-     * Get the Folio request handler function.
+     * Handle the Folio request.
      */
-    protected function handler(): Closure
+    public function handle(Request $request): mixed
     {
-        return function (Request $request) {
-            $this->terminateUsing = null;
+        $this->terminateUsing = null;
 
-            $mountPaths = collect($this->mountPaths)->filter(
-                fn (MountPath $mountPath) => str_starts_with(mb_strtolower('/'.$request->path()), $mountPath->baseUri)
-            )->all();
+        $mountPaths = collect($this->mountPaths)->filter(
+            fn (MountPath $mountPath) => str_starts_with(mb_strtolower('/'.$request->path()), $mountPath->baseUri)
+        )->all();
 
-            return (new RequestHandler(
-                $mountPaths,
-                $this->renderUsing,
-                fn (MatchedView $matchedView) => $this->lastMatchedView = $matchedView,
-            ))($request);
-        };
+        return (new RequestHandler(
+            $mountPaths,
+            $this->renderUsing,
+            fn (MatchedView $matchedView) => $this->lastMatchedView = $matchedView,
+        ))($request);
     }
 
     /**

--- a/tests/Feature/Console/RouteCacheCommandTest.php
+++ b/tests/Feature/Console/RouteCacheCommandTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use Illuminate\Support\Facades\Route;
 use Laravel\Folio\Folio;
+use Laravel\Folio\FolioManager;
 
 test('routes may be cached', function () {
     Folio::route(__DIR__.'/../resources/views/pages');
@@ -10,4 +12,18 @@ test('routes may be cached', function () {
     $command->expectsOutputToContain('Routes cached successfully.');
 
     $command->assertOk();
+});
+
+test('the fallback route does not serialize the manager into the route cache', function () {
+    Folio::route(__DIR__.'/../resources/views/pages');
+
+    Route::getRoutes()->refreshNameLookups();
+
+    $route = Route::getRoutes()->getByName('laravel-folio');
+
+    $route->prepareForSerialization();
+
+    expect($route->getAction('uses'))
+        ->toBe(FolioManager::class.'@handle')
+        ->not->toContain('Laravel\\SerializableClosure');
 });


### PR DESCRIPTION
Fixes #169 

Switched the fallback route from a closure to a controller action. Now unserialize()'s allowed_classes check in Laravel 13 won't catch the FolioManager class.