### PR TITLE
Support Livewire 4 single-file component pages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "symfony/console": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
+        "livewire/livewire": "^4.0",
         "orchestra/testbench": "^8.36|^9.15|^10.8|^11.0",
         "pestphp/pest": "^2.5|^3.0|^4.0",
         "phpstan/phpstan": "^1.10|^2.1"

--- a/src/Console/ListCommand.php
+++ b/src/Console/ListCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Stringable;
 use Laravel\Folio\FolioManager;
 use Laravel\Folio\FolioRoutes;
 use Laravel\Folio\MountPath;
+use Laravel\Folio\Support\LivewireComponents;
 use Laravel\Folio\Support\Project;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
@@ -100,6 +101,10 @@ class ListCommand extends RouteListCommand
                     }
 
                     $uri = str_replace('.blade.php', '', $uri);
+
+                    if (LivewireComponents::name($viewPath)) {
+                        $uri = LivewireComponents::stripEmojiPrefix($uri);
+                    }
 
                     $uri = collect(explode('/', $uri))
                         ->map(function (string $currentSegment) {

--- a/src/FolioRoutes.php
+++ b/src/FolioRoutes.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
 use Laravel\Folio\Exceptions\UrlGenerationException;
 use Laravel\Folio\Pipeline\MatchedView;
 use Laravel\Folio\Pipeline\PotentiallyBindablePathSegment;
+use Laravel\Folio\Support\LivewireComponents;
 use Laravel\Folio\Support\Project;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -160,6 +161,10 @@ class FolioRoutes
     protected function path(string $mountPath, string $path, array $parameters): array
     {
         $uri = str_replace('.blade.php', '', $path);
+
+        if (LivewireComponents::name(rtrim(Project::basePath(), '/').'/'.ltrim($path, '/'))) {
+            $uri = LivewireComponents::stripEmojiPrefix($uri);
+        }
 
         [$parameters, $usedParameters] = [collect($parameters), collect()];
 

--- a/src/FolioServiceProvider.php
+++ b/src/FolioServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Folio\Support\LivewireComponents;
 
 class FolioServiceProvider extends ServiceProvider
 {
@@ -32,8 +33,19 @@ class FolioServiceProvider extends ServiceProvider
         $this->registerCommands();
         $this->registerPublishing();
         $this->registerUrlGenerator();
+        $this->registerLivewireComponentResolver();
         $this->registerTerminationCallback();
         $this->cacheFolioRoutesOnRouteCache();
+    }
+
+    /**
+     * Register the resolver for Folio-specific Livewire component names.
+     */
+    protected function registerLivewireComponentResolver(): void
+    {
+        $this->callAfterResolving('livewire', function ($livewire) {
+            LivewireComponents::registerMissingComponentResolver($livewire);
+        });
     }
 
     /**

--- a/src/Pipeline/FindsWildcardViews.php
+++ b/src/Pipeline/FindsWildcardViews.php
@@ -4,6 +4,7 @@ namespace Laravel\Folio\Pipeline;
 
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
+use Laravel\Folio\Support\LivewireComponents;
 
 trait FindsWildcardViews
 {
@@ -38,9 +39,14 @@ trait FindsWildcardViews
             }
 
             $filename = $filename->before('.blade.php');
+            $normalizedFilename = LivewireComponents::stripEmojiPrefix((string) $filename);
 
-            return $filename->startsWith($startsWith) &&
-                   $filename->endsWith($endsWith);
+            if ($normalizedFilename !== (string) $filename && LivewireComponents::name($file->getPathname()) === null) {
+                return false;
+            }
+
+            return Str::startsWith($normalizedFilename, $startsWith) &&
+                   Str::endsWith($normalizedFilename, $endsWith);
         })?->getFilename();
     }
 }

--- a/src/Pipeline/MatchDirectoryIndexViews.php
+++ b/src/Pipeline/MatchDirectoryIndexViews.php
@@ -3,6 +3,7 @@
 namespace Laravel\Folio\Pipeline;
 
 use Closure;
+use Laravel\Folio\Support\LivewireComponents;
 
 class MatchDirectoryIndexViews
 {
@@ -13,7 +14,7 @@ class MatchDirectoryIndexViews
     {
         return $state->onLastUriSegment() &&
             $state->currentUriSegmentIsDirectory() &&
-            file_exists($path = $state->currentUriSegmentDirectory().'/index.blade.php')
+            ($path = LivewireComponents::findView($state->currentUriSegmentDirectory().'/index.blade.php'))
                 ? new MatchedView($path, $state->data)
                 : $next($state);
     }

--- a/src/Pipeline/MatchLiteralViews.php
+++ b/src/Pipeline/MatchLiteralViews.php
@@ -3,6 +3,7 @@
 namespace Laravel\Folio\Pipeline;
 
 use Closure;
+use Laravel\Folio\Support\LivewireComponents;
 
 class MatchLiteralViews
 {
@@ -12,7 +13,7 @@ class MatchLiteralViews
     public function __invoke(State $state, Closure $next): mixed
     {
         return $state->onLastUriSegment() &&
-            file_exists($path = $state->currentDirectory().'/'.$state->currentUriSegment().'.blade.php')
+            ($path = LivewireComponents::findView($state->currentDirectory().'/'.$state->currentUriSegment().'.blade.php'))
                 ? new MatchedView($path, $state->data)
                 : $next($state);
     }

--- a/src/Pipeline/MatchRootIndex.php
+++ b/src/Pipeline/MatchRootIndex.php
@@ -3,6 +3,7 @@
 namespace Laravel\Folio\Pipeline;
 
 use Closure;
+use Laravel\Folio\Support\LivewireComponents;
 
 class MatchRootIndex
 {
@@ -12,7 +13,7 @@ class MatchRootIndex
     public function __invoke(State $state, Closure $next): mixed
     {
         if (trim($state->uri) === '/') {
-            return file_exists($path = $state->mountPath.'/index.blade.php')
+            return ($path = LivewireComponents::findView($state->mountPath.'/index.blade.php'))
                     ? new MatchedView($path, $state->data)
                     : new StopIterating;
         }

--- a/src/Pipeline/MatchWildcardDirectories.php
+++ b/src/Pipeline/MatchWildcardDirectories.php
@@ -5,6 +5,7 @@ namespace Laravel\Folio\Pipeline;
 use Closure;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
+use Laravel\Folio\Support\LivewireComponents;
 
 class MatchWildcardDirectories
 {
@@ -27,7 +28,7 @@ class MatchWildcardDirectories
                 return new ContinueIterating($currentState);
             }
 
-            if (file_exists($path = $currentState->currentUriSegmentDirectory().'/index.blade.php')) {
+            if ($path = LivewireComponents::findView($currentState->currentUriSegmentDirectory().'/index.blade.php')) {
                 return new MatchedView($path, $currentState->data);
             }
         }

--- a/src/Pipeline/TransformModelBindings.php
+++ b/src/Pipeline/TransformModelBindings.php
@@ -5,6 +5,7 @@ namespace Laravel\Folio\Pipeline;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
+use Laravel\Folio\Support\LivewireComponents;
 
 class TransformModelBindings
 {
@@ -77,10 +78,10 @@ class TransformModelBindings
      */
     protected function bindablePathSegments(MatchedView $view): array
     {
-        return explode(DIRECTORY_SEPARATOR, (string) Str::of($view->path)
+        return explode(DIRECTORY_SEPARATOR, LivewireComponents::stripEmojiPrefix((string) Str::of($view->path)
             ->replace($view->mountPath, '')
             ->beforeLast('.blade.php')
-            ->trim(DIRECTORY_SEPARATOR));
+            ->trim(DIRECTORY_SEPARATOR)));
     }
 
     /**

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -99,7 +99,9 @@ class RequestHandler
     protected function toResponse(Request $request, MatchedView $matchedView): Response
     {
         if ($component = LivewireComponents::name($matchedView->path)) {
-            $request->route()->action['livewire_component'] = $component;
+            foreach ($matchedView->data as $key => $value) {
+                $request->route()->setParameter($key, $value);
+            }
 
             return Route::toResponse($request, app()->call([
                 app('livewire')->new($component), '__invoke',

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -9,6 +9,7 @@ use Illuminate\Routing\Pipeline;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\View;
 use Laravel\Folio\Pipeline\MatchedView;
+use Laravel\Folio\Support\LivewireComponents;
 use Symfony\Component\HttpFoundation\Response;
 
 class RequestHandler
@@ -97,6 +98,14 @@ class RequestHandler
      */
     protected function toResponse(Request $request, MatchedView $matchedView): Response
     {
+        if ($component = LivewireComponents::name($matchedView->path)) {
+            $request->route()->action['livewire_component'] = $component;
+
+            return Route::toResponse($request, app()->call([
+                app('livewire')->new($component), '__invoke',
+            ]));
+        }
+
         $view = View::file($matchedView->path, $matchedView->data);
 
         return Route::toResponse($request, app()->call(

--- a/src/Support/LivewireComponents.php
+++ b/src/Support/LivewireComponents.php
@@ -2,8 +2,24 @@
 
 namespace Laravel\Folio\Support;
 
+use Laravel\Folio\FolioManager;
+
 class LivewireComponents
 {
+    /**
+     * Register a resolver for component names that represent Folio wildcard files.
+     */
+    public static function registerMissingComponentResolver(mixed $livewire): void
+    {
+        $livewire->resolveMissingComponent(function ($name) {
+            if (! is_string($name) || ! $path = static::pathFromFolioComponentName($name)) {
+                return null;
+            }
+
+            return app('livewire.compiler')->compile($path);
+        });
+    }
+
     /**
      * Find a view at the given path, including Livewire's optional emoji prefix.
      */
@@ -40,12 +56,18 @@ class LivewireComponents
                 if (app('livewire')->exists($component)) {
                     return $component;
                 }
+
+                return static::registerFolioComponent($path);
             }
         }
 
         foreach (config('livewire.component_locations', []) as $location) {
-            if (($name = static::nameWithinLocation($path, $location)) !== null && app('livewire')->exists($name)) {
-                return $name;
+            if (($name = static::nameWithinLocation($path, $location)) !== null) {
+                if (app('livewire')->exists($name)) {
+                    return $name;
+                }
+
+                return static::registerFolioComponent($path);
             }
         }
 
@@ -93,5 +115,86 @@ class LivewireComponents
         return str_replace('/', '.', static::stripEmojiPrefix(
             substr($path, strlen($location) + 1, -strlen('.blade.php'))
         ));
+    }
+
+    /**
+     * Register a Folio view under a stable Livewire component name.
+     */
+    protected static function registerFolioComponent(string $path): ?string
+    {
+        $path = realpath($path);
+
+        foreach (app(FolioManager::class)->mountPaths() as $index => $mountPath) {
+            $mountPath = realpath($mountPath->path);
+
+            if (! $path || ! $mountPath || ! str_starts_with($path, $mountPath.DIRECTORY_SEPARATOR)) {
+                continue;
+            }
+
+            $relativePath = substr($path, strlen($mountPath) + 1);
+            $component = 'folio-'.$index.'-'.static::base64UrlEncode($relativePath);
+
+            app('livewire')->addComponent($component, viewPath: $path);
+
+            return $component;
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve a Folio component name back to its configured Livewire view.
+     */
+    protected static function pathFromFolioComponentName(string $name): ?string
+    {
+        if (preg_match('/^folio-(\d+)-([A-Za-z0-9_-]+)$/', $name, $matches) !== 1) {
+            return null;
+        }
+
+        $mountPath = app(FolioManager::class)->mountPaths()[(int) $matches[1]] ?? null;
+        $relativePath = static::base64UrlDecode($matches[2]);
+
+        if (! $mountPath || $relativePath === null || str_contains($relativePath, "\0")) {
+            return null;
+        }
+
+        $mountPath = realpath($mountPath->path);
+        $path = $mountPath ? realpath($mountPath.DIRECTORY_SEPARATOR.$relativePath) : false;
+
+        if (! $path || ! str_starts_with($path, $mountPath.DIRECTORY_SEPARATOR)) {
+            return null;
+        }
+
+        foreach ([...array_values(config('livewire.component_namespaces', [])), ...config('livewire.component_locations', [])] as $location) {
+            if (static::nameWithinLocation($path, $location) !== null && static::hasValidSingleFileComponentSource($path)) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Encode a relative path for use in a Livewire component name.
+     */
+    protected static function base64UrlEncode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+
+    /**
+     * Decode a relative path from a Livewire component name.
+     */
+    protected static function base64UrlDecode(string $value): ?string
+    {
+        $padding = strlen($value) % 4;
+
+        if ($padding) {
+            $value .= str_repeat('=', 4 - $padding);
+        }
+
+        $decoded = base64_decode(strtr($value, '-_', '+/'), true);
+
+        return $decoded === false ? null : $decoded;
     }
 }

--- a/src/Support/LivewireComponents.php
+++ b/src/Support/LivewireComponents.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Laravel\Folio\Support;
+
+class LivewireComponents
+{
+    /**
+     * Find a view at the given path, including Livewire's optional emoji prefix.
+     */
+    public static function findView(string $path): ?string
+    {
+        if (file_exists($path)) {
+            return $path;
+        }
+
+        foreach (["⚡", "⚡\u{FE0E}", "⚡\u{FE0F}"] as $prefix) {
+            $prefixedPath = dirname($path).DIRECTORY_SEPARATOR.$prefix.basename($path);
+
+            if (file_exists($prefixedPath) && static::name($prefixedPath) !== null) {
+                return $prefixedPath;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the Livewire component name for the given view path.
+     */
+    public static function name(string $path): ?string
+    {
+        if (! app()->bound('livewire') || ! static::hasValidSingleFileComponentSource($path)) {
+            return null;
+        }
+
+        foreach (config('livewire.component_namespaces', []) as $namespace => $location) {
+            if (($name = static::nameWithinLocation($path, $location)) !== null) {
+                $component = $namespace.'::'.$name;
+
+                if (app('livewire')->exists($component)) {
+                    return $component;
+                }
+            }
+        }
+
+        foreach (config('livewire.component_locations', []) as $location) {
+            if (($name = static::nameWithinLocation($path, $location)) !== null && app('livewire')->exists($name)) {
+                return $name;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Strip Livewire's optional emoji prefix from path segments.
+     */
+    public static function stripEmojiPrefix(string $path): string
+    {
+        return (string) preg_replace('/(^|\/)\x{26A1}[\x{FE0E}\x{FE0F}]?/u', '$1', $path);
+    }
+
+    /**
+     * Determine if the view contains a Livewire single-file component.
+     */
+    protected static function hasValidSingleFileComponentSource(string $path): bool
+    {
+        if (! is_file($path)) {
+            return false;
+        }
+
+        $contents = file_get_contents($path);
+
+        return $contents !== false && preg_match('/\<\?php.*new\s+.*class/s', $contents) === 1;
+    }
+
+    /**
+     * Get the component name for a view within the given location.
+     */
+    protected static function nameWithinLocation(string $path, mixed $location): ?string
+    {
+        if (! is_string($location) || ! $location = realpath($location)) {
+            return null;
+        }
+
+        $path = str_replace(DIRECTORY_SEPARATOR, '/', realpath($path) ?: $path);
+        $location = rtrim(str_replace(DIRECTORY_SEPARATOR, '/', $location), '/');
+
+        if (! str_starts_with($path, $location.'/') || ! str_ends_with($path, '.blade.php')) {
+            return null;
+        }
+
+        return str_replace('/', '.', static::stripEmojiPrefix(
+            substr($path, strlen($location) + 1, -strlen('.blade.php'))
+        ));
+    }
+}

--- a/tests/Feature/LivewireTest.php
+++ b/tests/Feature/LivewireTest.php
@@ -1,8 +1,12 @@
 <?php
 
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schema;
 use Laravel\Folio\Folio;
+use Laravel\Folio\Support\LivewireComponents;
+use Livewire\Component;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Tests\Feature\Fixtures\Podcast;
 
 beforeEach(function () {
     $path = __DIR__.'/resources/views/livewire-pages';
@@ -48,6 +52,45 @@ test('emoji-prefixed wildcard components receive folio route parameters', functi
     ['/andrew', 'Profile: andrew'],
     ['/teams/lineweb', 'Team: lineweb'],
 ]);
+
+test('emoji-prefixed multi-segment model wildcard components may be used as folio pages', function () {
+    Schema::create('podcasts', function ($table) {
+        $table->id();
+        $table->string('name');
+        $table->timestamps();
+        $table->softDeletes();
+    });
+
+    $firstPodcast = Podcast::create(['name' => 'First podcast']);
+    $secondPodcast = Podcast::create(['name' => 'Second podcast']);
+
+    $this->get("/podcasts/{$firstPodcast->id}/{$secondPodcast->id}")
+        ->assertOk()
+        ->assertSee('First podcast, Second podcast')
+        ->assertSee('wire:snapshot', false);
+});
+
+test('livewire component route metadata is cleared after handling the request', function () {
+    $this->get('/counter')->assertOk();
+
+    expect(request()->route()->getAction('livewire_component'))->toBeNull();
+});
+
+test('folio wildcard component names resolve in a fresh application', function () {
+    $path = __DIR__.'/resources/views/livewire-pages';
+    $view = $path.'/podcasts/⚡[...Tests.Feature.Fixtures.Podcast].blade.php';
+    $component = LivewireComponents::name($view);
+
+    expect($component)->toStartWith('folio-');
+
+    $this->refreshApplication();
+
+    config()->set('livewire.component_namespaces.pages', $path);
+    app('livewire')->addNamespace('pages', viewPath: $path);
+    Folio::route($path);
+
+    expect(app('livewire')->new($component))->toBeInstanceOf(Component::class);
+});
 
 test('folio route listings and named urls omit the emoji prefix', function () {
     $output = new BufferedOutput;

--- a/tests/Feature/LivewireTest.php
+++ b/tests/Feature/LivewireTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+use Laravel\Folio\Folio;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+beforeEach(function () {
+    $path = __DIR__.'/resources/views/livewire-pages';
+
+    config()->set('livewire.component_layout', 'components.app');
+    config()->set('livewire.component_namespaces.pages', $path);
+
+    app('livewire')->addNamespace('pages', viewPath: $path);
+
+    Folio::route($path);
+});
+
+test('livewire single-file components may be used as folio pages', function () {
+    $this->get('/counter')
+        ->assertOk()
+        ->assertSee('Count: 1')
+        ->assertSee('wire:snapshot', false);
+});
+
+test('livewire single-file components with an emoji prefix use the unprefixed uri', function () {
+    $this->get('/profile')
+        ->assertOk()
+        ->assertSee('Livewire profile')
+        ->assertSee('wire:snapshot', false);
+});
+
+test('emoji-prefixed index components match folio index routes', function (string $uri, string $content) {
+    $this->get($uri)
+        ->assertOk()
+        ->assertSee($content)
+        ->assertSee('wire:snapshot', false);
+})->with([
+    ['/', 'Livewire home'],
+    ['/settings', 'Livewire settings'],
+]);
+
+test('emoji-prefixed wildcard components receive folio route parameters', function (string $uri, string $content) {
+    $this->get($uri)
+        ->assertOk()
+        ->assertSee($content)
+        ->assertSee('wire:snapshot', false);
+})->with([
+    ['/andrew', 'Profile: andrew'],
+    ['/teams/lineweb', 'Team: lineweb'],
+]);
+
+test('folio route listings and named urls omit the emoji prefix', function () {
+    $output = new BufferedOutput;
+
+    Artisan::call('folio:list', ['--json' => true], $output);
+
+    $routes = collect(json_decode($output->fetch(), true, flags: JSON_THROW_ON_ERROR));
+
+    expect($routes->pluck('uri'))
+        ->toContain('/profile')
+        ->not->toContain('/⚡profile')
+        ->and(route('livewire.profile', [], false))->toBe('/profile');
+});

--- a/tests/Feature/resources/views/livewire-pages/counter.blade.php
+++ b/tests/Feature/resources/views/livewire-pages/counter.blade.php
@@ -1,0 +1,12 @@
+<?php
+
+use Livewire\Component;
+
+new class extends Component
+{
+    public int $count = 1;
+};
+
+?>
+
+<div>Count: {{ $count }}</div>

--- a/tests/Feature/resources/views/livewire-pages/podcasts/⚡[...Tests.Feature.Fixtures.Podcast].blade.php
+++ b/tests/Feature/resources/views/livewire-pages/podcasts/⚡[...Tests.Feature.Fixtures.Podcast].blade.php
@@ -1,0 +1,17 @@
+<?php
+
+use Livewire\Component;
+
+new class extends Component
+{
+    public $podcasts;
+
+    public function mount($podcasts): void
+    {
+        $this->podcasts = $podcasts;
+    }
+};
+
+?>
+
+<div>{{ collect($podcasts)->pluck('name')->join(', ') }}</div>

--- a/tests/Feature/resources/views/livewire-pages/settings/⚡index.blade.php
+++ b/tests/Feature/resources/views/livewire-pages/settings/⚡index.blade.php
@@ -1,0 +1,12 @@
+<?php
+
+use Livewire\Component;
+
+new class extends Component
+{
+    public string $heading = 'Livewire settings';
+};
+
+?>
+
+<div>{{ $heading }}</div>

--- a/tests/Feature/resources/views/livewire-pages/teams/[team]/⚡index.blade.php
+++ b/tests/Feature/resources/views/livewire-pages/teams/[team]/⚡index.blade.php
@@ -1,0 +1,17 @@
+<?php
+
+use Livewire\Component;
+
+new class extends Component
+{
+    public string $team;
+
+    public function mount(string $team): void
+    {
+        $this->team = $team;
+    }
+};
+
+?>
+
+<div>Team: {{ $team }}</div>

--- a/tests/Feature/resources/views/livewire-pages/⚡[slug].blade.php
+++ b/tests/Feature/resources/views/livewire-pages/⚡[slug].blade.php
@@ -1,0 +1,17 @@
+<?php
+
+use Livewire\Component;
+
+new class extends Component
+{
+    public string $slug;
+
+    public function mount(string $slug): void
+    {
+        $this->slug = $slug;
+    }
+};
+
+?>
+
+<div>Profile: {{ $slug }}</div>

--- a/tests/Feature/resources/views/livewire-pages/⚡index.blade.php
+++ b/tests/Feature/resources/views/livewire-pages/⚡index.blade.php
@@ -1,0 +1,12 @@
+<?php
+
+use Livewire\Component;
+
+new class extends Component
+{
+    public string $heading = 'Livewire home';
+};
+
+?>
+
+<div>{{ $heading }}</div>

--- a/tests/Feature/resources/views/livewire-pages/⚡profile.blade.php
+++ b/tests/Feature/resources/views/livewire-pages/⚡profile.blade.php
@@ -1,0 +1,14 @@
+<?php
+
+use Livewire\Component;
+
+new class extends Component
+{
+    public string $heading = 'Livewire profile';
+};
+
+Laravel\Folio\name('livewire.profile');
+
+?>
+
+<div>{{ $heading }}</div>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\View;
 use Laravel\Folio\FolioServiceProvider;
 use Laravel\Folio\MountPath;
 use Laravel\Folio\Router;
+use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 
 abstract class TestCase extends OrchestraTestCase
@@ -31,6 +32,7 @@ abstract class TestCase extends OrchestraTestCase
     {
         return [
             FolioServiceProvider::class,
+            LivewireServiceProvider::class,
         ];
     }
 


### PR DESCRIPTION
This allows Folio-mounted page directories to contain Livewire 4 single-file components.

Folio currently renders every matched Blade file through `View::file`. For a Livewire SFC, that discards the component instance and leaves its public properties unavailable to the template. Livewire's default optional `⚡` filename prefix is also treated as part of the Folio URL instead of component metadata.

This change:

- resolves SFCs from Livewire's configured component namespaces and locations, while remaining optional when Livewire is not installed;
- renders a matched SFC through Livewire's page-component lifecycle;
- supports prefixed literal, index, and wildcard Folio pages; and
- removes the prefix from route listings and named URL generation.

Plain Blade pages keep the existing rendering path.

Validation:

- `vendor/bin/pest` — 214 tests, 467 assertions on Laravel 13 / Livewire 4.3 and Laravel 12 / Livewire 4.0
- `vendor/bin/phpstan analyse --no-progress --memory-limit=512M`
- `composer validate --strict`

Fixes #173.
