### PR TITLE
Fix 'folio:list' command on Laravel 13

### DIFF
--- a/src/Console/ListCommand.php
+++ b/src/Console/ListCommand.php
@@ -19,6 +19,20 @@ use Symfony\Component\Finder\SplFileInfo;
 class ListCommand extends RouteListCommand
 {
     /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'folio:list
+                    {--json : Output the route list as JSON}
+                    {--name= : Filter the routes by name}
+                    {--domain= : Filter the routes by domain}
+                    {--path= : Only show routes matching the given path pattern}
+                    {--except-path= : Do not display the routes matching the given path pattern}
+                    {--r|reverse : Reverse the ordering of the routes}
+                    {--sort=uri : The column (domain, name, uri, view) to sort by}';
+
+    /**
      * The console command name.
      *
      * @var string


### PR DESCRIPTION
`ListCommand` extends `RouteListCommand` which defines `protected $signature = 'route:list ...'`. When no `$signature` is defined on the child, the inherited signature causes `Command::__construct()` to parse the command name as `route:list` instead of `folio:list`.

This conflicts with the `#[AsCommand(name: 'folio:list')]` attribute used by the lazy command loader, causing:

```
ERROR  The "folio:list" command cannot be found because it is registered under multiple names.
```

**The fix:** Add an explicit `$signature` property with options matching `getOptions()`. This is a single-property change — no behavior modifications.

**Backward compatibility:** Verified on Laravel 10, 11, 12, and 13. The `Command::__construct()` code path changes from the `else` branch (`parent::__construct($this->name)`) to the fluent definition branch, but both parse to the same result on Laravel 10–12 where `RouteListCommand` had no `$signature`. On Laravel 13, it fixes the crash.

| Laravel | Baseline (before fix) | After fix |
|---------|----------------------|------------|
| 10      | ✓ | ✓ |
| 11      | ✓ | ✓ |
| 12      | ✓ | ✓ |
| 13      | ✗ (crash) | ✓ |