### PR TITLE
Remove `getOptions()` method from `folio:list` command

### DIFF
--- a/src/Console/ListCommand.php
+++ b/src/Console/ListCommand.php
@@ -283,22 +283,4 @@ class ListCommand extends RouteListCommand
 
         return $routes;
     }
-
-    /**
-     * Get the console command options.
-     *
-     * @return array<int, array<int, int|string|null>>
-     */
-    protected function getOptions(): array
-    {
-        return [
-            ['json', null, InputOption::VALUE_NONE, 'Output the route list as JSON'],
-            ['name', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by name'],
-            ['domain', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by domain'],
-            ['path', null, InputOption::VALUE_OPTIONAL, 'Only show routes matching the given path pattern'],
-            ['except-path', null, InputOption::VALUE_OPTIONAL, 'Do not display the routes matching the given path pattern'],
-            ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes'],
-            ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (domain, name, uri, view) to sort by', 'uri'],
-        ];
-    }
 }


### PR DESCRIPTION
`getOptions()` method will be ignored if the command is registered using `$signature` instead of `$name`

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
