### PR TITLE
Warn about shadowed Folio routes

### DIFF
--- a/src/Console/ListCommand.php
+++ b/src/Console/ListCommand.php
@@ -18,6 +18,13 @@ use Symfony\Component\Finder\SplFileInfo;
 class ListCommand extends RouteListCommand
 {
     /**
+     * The routes shadowed by an earlier mounted route.
+     *
+     * @var Collection<int, array{winner: array<string, string|null>, shadowed: array<string, string|null>}>
+     */
+    protected Collection $collisions;
+
+    /**
      * The name and signature of the console command.
      *
      * @var string
@@ -60,6 +67,8 @@ class ListCommand extends RouteListCommand
             $this->displayRoutes(
                 $this->toDisplayableFormat($routes->all()),
             );
+
+            $this->displayCollisionWarnings();
         }
     }
 
@@ -86,7 +95,7 @@ class ListCommand extends RouteListCommand
      */
     protected function routesFromMountPaths(array $mountPaths): Collection
     {
-        return collect($mountPaths)->map(function (MountPath $mountPath) {
+        $routes = collect($mountPaths)->map(function (MountPath $mountPath) {
             $views = Finder::create()->in($mountPath->path)->name('*.blade.php')->files()->getIterator();
 
             $baseUri = rtrim($mountPath->baseUri, '/');
@@ -155,9 +164,54 @@ class ListCommand extends RouteListCommand
                         'view' => $action,
                     ];
                 });
-        })->flatten(1)
-            ->unique(fn (array $route) => ($route['domain'] ?? '').'|'.$route['uri'])
+        })->flatten(1);
+
+        $this->collisions = $routes
+            ->groupBy(fn (array $route) => $this->collisionKey($route))
+            ->filter(fn (Collection $routes) => $routes->count() > 1)
+            ->flatMap(fn (Collection $routes) => $routes->skip(1)->map(fn (array $shadowed) => [
+                'winner' => $routes->first(),
+                'shadowed' => $shadowed,
+            ]))
             ->values();
+
+        return $routes
+            ->unique(fn (array $route) => $this->collisionKey($route))
+            ->values();
+    }
+
+    /**
+     * Get the key used to identify exact route collisions.
+     *
+     * @param  array<string, string|null>  $route
+     */
+    protected function collisionKey(array $route): string
+    {
+        return ($route['domain'] ?? '').'|'.$route['uri'];
+    }
+
+    /**
+     * Display warnings for routes shadowed by an earlier mount.
+     */
+    protected function displayCollisionWarnings(): void
+    {
+        if ($this->option('json')) {
+            return;
+        }
+
+        $this->collisions
+            ->filter(fn (array $collision) => $this->filterRoute($collision['winner']))
+            ->each(function (array $collision) {
+                $route = $collision['winner'];
+                $location = $route['domain'] ? $route['domain'].$route['uri'] : $route['uri'];
+
+                $this->components->warn(sprintf(
+                    'Folio route [%s] from [%s] shadows [%s].',
+                    $location,
+                    $collision['winner']['view'],
+                    $collision['shadowed']['view'],
+                ));
+            });
     }
 
     /**

--- a/tests/Feature/Console/ListCommandTest.php
+++ b/tests/Feature/Console/ListCommandTest.php
@@ -291,5 +291,95 @@ test('multiple domains with overlapping paths', function () {
         ->and($content)->toContain('domain-two/index.blade.php')
         ->and($content)->toContain('domain-one/about.blade.php')
         ->and($content)->toContain('domain-two/about.blade.php')
-        ->and($content)->toContain('Showing [4] routes');
+        ->and($content)->toContain('Showing [4] routes')
+        ->and($content)->not->toContain('shadows');
+});
+
+test('routes shadowed by an earlier mount are reported', function () {
+    $output = new BufferedOutput;
+
+    Folio::path(__DIR__.'/../resources/views/domain-one')->domain('example.com');
+    Folio::path(__DIR__.'/../resources/views/domain-two')->domain('example.com');
+
+    $exitCode = Artisan::call('folio:list', [], $output);
+    $content = $output->fetch();
+
+    expect($exitCode)->toBe(0)
+        ->and($content)->toContain('Showing [2] routes')
+        ->and($content)->toContain('Folio route [example.com/]')
+        ->and($content)->toContain('domain-one/index.blade.php] shadows [tests/Feature/resources/views/domain-two/index.blade.php]')
+        ->and($content)->toContain('Folio route [example.com/about]')
+        ->and($content)->toContain('domain-one/about.blade.php] shadows [tests/Feature/resources/views/domain-two/about.blade.php]');
+});
+
+test('collision warnings do not corrupt JSON output', function () {
+    $output = new BufferedOutput;
+
+    Folio::path(__DIR__.'/../resources/views/domain-one')->domain('example.com');
+    Folio::path(__DIR__.'/../resources/views/domain-two')->domain('example.com');
+
+    $exitCode = Artisan::call('folio:list', ['--json' => true], $output);
+    $content = $output->fetch();
+
+    expect($exitCode)->toBe(0)
+        ->and(json_decode($content, true, flags: JSON_THROW_ON_ERROR))->toHaveCount(2)
+        ->and($content)->not->toContain('shadows');
+});
+
+test('routes without a domain report collisions', function () {
+    $output = new BufferedOutput;
+
+    Folio::path(__DIR__.'/../resources/views/domain-one');
+    Folio::path(__DIR__.'/../resources/views/domain-two');
+
+    $exitCode = Artisan::call('folio:list', [], $output);
+    $content = $output->fetch();
+
+    expect($exitCode)->toBe(0)
+        ->and($content)->toContain('Folio route [/]')
+        ->and($content)->toContain('Folio route [/about]')
+        ->and($content)->toContain('Showing [2] routes');
+});
+
+test('collision warnings respect route filters', function () {
+    $output = new BufferedOutput;
+
+    Folio::path(__DIR__.'/../resources/views/domain-one')->domain('example.com');
+    Folio::path(__DIR__.'/../resources/views/domain-two')->domain('example.com');
+
+    $exitCode = Artisan::call('folio:list', ['--path' => 'missing'], $output);
+    $content = $output->fetch();
+
+    expect($exitCode)->toBe(0)
+        ->and($content)->toContain('Showing [0] routes')
+        ->and($content)->not->toContain('shadows');
+});
+
+test('except-path only reports collisions that remain visible', function () {
+    $output = new BufferedOutput;
+
+    Folio::path(__DIR__.'/../resources/views/domain-one')->domain('example.com');
+    Folio::path(__DIR__.'/../resources/views/domain-two')->domain('example.com');
+
+    $exitCode = Artisan::call('folio:list', ['--except-path' => 'about'], $output);
+    $content = $output->fetch();
+
+    expect($exitCode)->toBe(0)
+        ->and($content)->toContain('Folio route [example.com/]')
+        ->and($content)->not->toContain('Folio route [example.com/about]');
+});
+
+test('every route shadowed by the winner is reported', function () {
+    $output = new BufferedOutput;
+
+    Folio::path(__DIR__.'/../resources/views/domain-one')->domain('example.com');
+    Folio::path(__DIR__.'/../resources/views/domain-one')->domain('example.com');
+    Folio::path(__DIR__.'/../resources/views/domain-one')->domain('example.com');
+
+    $exitCode = Artisan::call('folio:list', [], $output);
+    $content = $output->fetch();
+
+    expect($exitCode)->toBe(0)
+        ->and($content)->toContain('Showing [2] routes')
+        ->and(substr_count($content, 'shadows'))->toBe(4);
 });


### PR DESCRIPTION
`folio:list` keeps the first page when multiple mounted paths produce the same domain and URI, but it currently gives no indication that later pages were discarded.

This change reports each shadowed page after the human-readable route table. Collision identity remains domain-aware, so the same URI on different domains is not reported. JSON output remains valid and warnings follow the existing `--path` and `--except-path` filters.

Routing behavior is unchanged; this only makes the existing first-match behavior visible.

Tests cover same-domain and domainless collisions, different domains, multiple shadowed pages, filtered output, and JSON output.

Validation:

- 213 package tests (469 assertions)
- PHPStan
- Fresh Laravel 13 application using this branch through a Composer path repository
