### PR TITLE
Support selecting Folio page mounts

### DIFF
--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -18,6 +18,11 @@ use function Laravel\Prompts\select;
 class MakeCommand extends GeneratorCommand
 {
     /**
+     * The resolved mounted path.
+     */
+    protected ?string $resolvedMountPath = null;
+
+    /**
      * The name and signature of the console command.
      *
      * @var string
@@ -46,13 +51,23 @@ class MakeCommand extends GeneratorCommand
     protected $aliases = ['make:folio'];
 
     /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $this->resolvedMountPath = null;
+
+        return parent::handle();
+    }
+
+    /**
      * Get the destination view path.
      *
      * @param  string  $name
      */
     protected function getPath($name): string
     {
-        $mountPath = $this->mountPath();
+        $mountPath = $this->resolvedMountPath ??= $this->mountPath();
 
         return $mountPath.'/'.preg_replace_callback(
             '/(?:\[.*?\])|(\w+)/',
@@ -72,30 +87,20 @@ class MakeCommand extends GeneratorCommand
 
         $mount = $this->option('mount');
 
-        if ($mountPaths->isEmpty()) {
-            if ($mount !== null) {
-                throw new InvalidArgumentException('The mount option may only be used when a Folio path is configured.');
-            }
-
-            return resource_path('views/pages');
-        }
-
         if ($mount !== null) {
-            $matches = $mountPaths->filter(fn (MountPath $mountPath) => in_array(
+            return $mountPaths->first(fn (MountPath $mountPath) => in_array(
                 $this->normalizePath($mount),
                 [$this->normalizePath($mountPath->path), $this->normalizePath(Project::relativePathOf($mountPath->path))],
                 true,
+            ))?->path ?? throw new InvalidArgumentException(sprintf(
+                'The mount [%s] is not one of the configured Folio paths: %s.',
+                $mount,
+                $mountPaths->map(fn (MountPath $mountPath) => Project::relativePathOf($mountPath->path))->join(', '),
             ));
+        }
 
-            if ($matches->count() !== 1) {
-                throw new InvalidArgumentException(sprintf(
-                    'The mount [%s] is not one of the configured Folio paths: %s.',
-                    $mount,
-                    $mountPaths->map(fn (MountPath $mountPath) => Project::relativePathOf($mountPath->path))->join(', '),
-                ));
-            }
-
-            return $matches->first()->path;
+        if ($mountPaths->isEmpty()) {
+            return resource_path('views/pages');
         }
 
         if ($mountPaths->count() === 1 || ! $this->input->isInteractive()) {
@@ -151,8 +156,8 @@ class MakeCommand extends GeneratorCommand
     protected function getOptions(): array
     {
         return [
-            ['force', 'f', InputOption::VALUE_NONE, 'Create the Folio page even if the page already exists'],
             ['mount', null, InputOption::VALUE_REQUIRED, 'The configured Folio path where the page should be created'],
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the Folio page even if the page already exists'],
         ];
     }
 

--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -5,9 +5,14 @@ namespace Laravel\Folio\Console;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use Laravel\Folio\Folio;
+use Laravel\Folio\MountPath;
+use Laravel\Folio\Support\Project;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
+
+use function Laravel\Prompts\select;
 
 #[AsCommand(name: 'folio:page', aliases: ['make:folio'])]
 class MakeCommand extends GeneratorCommand
@@ -47,13 +52,85 @@ class MakeCommand extends GeneratorCommand
      */
     protected function getPath($name): string
     {
-        $mountPath = Folio::paths()[0] ?? resource_path('views/pages');
+        $mountPath = $this->mountPath();
 
         return $mountPath.'/'.preg_replace_callback(
             '/(?:\[.*?\])|(\w+)/',
             fn (array $matches) => empty($matches[1]) ? $matches[0] : Str::lower($matches[1]),
             Str::finish($this->argument('name'), '.blade.php')
         );
+    }
+
+    /**
+     * Resolve the mounted path where the page should be created.
+     */
+    protected function mountPath(): string
+    {
+        $mountPaths = collect(Folio::mountPaths())
+            ->unique(fn (MountPath $mountPath) => $this->normalizePath($mountPath->path))
+            ->values();
+
+        $mount = $this->option('mount');
+
+        if ($mountPaths->isEmpty()) {
+            if ($mount !== null) {
+                throw new InvalidArgumentException('The mount option may only be used when a Folio path is configured.');
+            }
+
+            return resource_path('views/pages');
+        }
+
+        if ($mount !== null) {
+            $matches = $mountPaths->filter(fn (MountPath $mountPath) => in_array(
+                $this->normalizePath($mount),
+                [$this->normalizePath($mountPath->path), $this->normalizePath(Project::relativePathOf($mountPath->path))],
+                true,
+            ));
+
+            if ($matches->count() !== 1) {
+                throw new InvalidArgumentException(sprintf(
+                    'The mount [%s] is not one of the configured Folio paths: %s.',
+                    $mount,
+                    $mountPaths->map(fn (MountPath $mountPath) => Project::relativePathOf($mountPath->path))->join(', '),
+                ));
+            }
+
+            return $matches->first()->path;
+        }
+
+        if ($mountPaths->count() === 1 || ! $this->input->isInteractive()) {
+            return $mountPaths->first()->path;
+        }
+
+        return select(
+            label: 'Which Folio path should the page be created in?',
+            options: $mountPaths->mapWithKeys(fn (MountPath $mountPath) => [
+                $mountPath->path => $this->mountPathLabel($mountPath),
+            ]),
+            default: $mountPaths->first()->path,
+        );
+    }
+
+    /**
+     * Get the display label for a mounted path.
+     */
+    protected function mountPathLabel(MountPath $mountPath): string
+    {
+        $label = Project::relativePathOf($mountPath->path).' (URI: '.$mountPath->baseUri;
+
+        if ($mountPath->domain) {
+            $label .= ', Domain: '.$mountPath->domain;
+        }
+
+        return $label.')';
+    }
+
+    /**
+     * Normalize a path for comparison.
+     */
+    protected function normalizePath(string $path): string
+    {
+        return rtrim(str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path), DIRECTORY_SEPARATOR);
     }
 
     /**
@@ -73,6 +150,7 @@ class MakeCommand extends GeneratorCommand
     {
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the Folio page even if the page already exists'],
+            ['mount', null, InputOption::VALUE_REQUIRED, 'The configured Folio path where the page should be created'],
         ];
     }
 

--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -102,13 +102,15 @@ class MakeCommand extends GeneratorCommand
             return $mountPaths->first()->path;
         }
 
-        return select(
+        $selectedMountPath = select(
             label: 'Which Folio path should the page be created in?',
-            options: $mountPaths->mapWithKeys(fn (MountPath $mountPath) => [
-                $mountPath->path => $this->mountPathLabel($mountPath),
-            ]),
-            default: $mountPaths->first()->path,
+            options: $mountPaths->map(fn (MountPath $mountPath) => $this->mountPathLabel($mountPath)),
+            default: $this->mountPathLabel($mountPaths->first()),
         );
+
+        return $mountPaths->first(
+            fn (MountPath $mountPath) => $this->mountPathLabel($mountPath) === $selectedMountPath
+        )->path;
     }
 
     /**

--- a/tests/Feature/Console/MakeCommandTest.php
+++ b/tests/Feature/Console/MakeCommandTest.php
@@ -1,6 +1,10 @@
 <?php
 
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Artisan;
+use Laravel\Folio\Folio;
+use Laravel\Folio\Support\Project;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 beforeEach(function () {
     File::partialMock();
@@ -34,9 +38,161 @@ it('makes routes', function (string $name, string $path) {
 afterEach(function () {
     collect([
         resource_path('views/pages'),
+        resource_path('views/admin-pages'),
+        resource_path('views/site-pages'),
     ])->each(function (string $path) {
         if (File::exists($path)) {
             File::deleteDirectory($path);
         }
     });
 });
+
+it('makes a page in a selected mounted path', function () {
+    File::makeDirectory(resource_path('views/admin-pages'), recursive: true, force: true);
+    File::makeDirectory(resource_path('views/site-pages'), recursive: true, force: true);
+
+    Folio::path(resource_path('views/admin-pages'))->uri('/admin');
+    Folio::path(resource_path('views/site-pages'))->uri('/site')->domain('example.com');
+
+    $this->artisan('folio:page', ['name' => 'dashboard', '--force' => true])
+        ->expectsChoice(
+            'Which Folio path should the page be created in?',
+            resource_path('views/site-pages'),
+            [
+                resource_path('views/admin-pages') => Project::relativePathOf(resource_path('views/admin-pages')).' (URI: /admin)',
+                resource_path('views/site-pages') => Project::relativePathOf(resource_path('views/site-pages')).' (URI: /site, Domain: example.com)',
+            ],
+        )
+        ->assertOk();
+
+    expect(resource_path('views/site-pages/dashboard.blade.php'))->toBeFile();
+});
+
+it('accepts an absolute mounted path option', function () {
+    File::makeDirectory(resource_path('views/admin-pages'), recursive: true, force: true);
+    File::makeDirectory(resource_path('views/site-pages'), recursive: true, force: true);
+
+    Folio::path(resource_path('views/admin-pages'));
+    Folio::path(resource_path('views/site-pages'));
+
+    $this->artisan('folio:page', [
+        'name' => 'dashboard',
+        '--mount' => resource_path('views/site-pages'),
+    ])->assertOk();
+
+    expect(resource_path('views/site-pages/dashboard.blade.php'))->toBeFile();
+});
+
+it('accepts a project relative mounted path option', function () {
+    File::makeDirectory(resource_path('views/admin-pages'), recursive: true, force: true);
+    File::makeDirectory(resource_path('views/site-pages'), recursive: true, force: true);
+
+    Folio::path(resource_path('views/admin-pages'));
+    Folio::path(resource_path('views/site-pages'));
+
+    $this->artisan('folio:page', [
+        'name' => 'dashboard',
+        '--mount' => Project::relativePathOf(resource_path('views/site-pages')),
+    ])->assertOk();
+
+    expect(resource_path('views/site-pages/dashboard.blade.php'))->toBeFile();
+});
+
+it('accepts a mounted path option with a trailing separator', function () {
+    File::makeDirectory(resource_path('views/admin-pages'), recursive: true, force: true);
+    File::makeDirectory(resource_path('views/site-pages'), recursive: true, force: true);
+
+    Folio::path(resource_path('views/admin-pages'));
+    Folio::path(resource_path('views/site-pages'));
+
+    $this->artisan('folio:page', [
+        'name' => 'dashboard',
+        '--mount' => resource_path('views/site-pages').'/',
+    ])->assertOk();
+
+    expect(resource_path('views/site-pages/dashboard.blade.php'))->toBeFile();
+});
+
+it('accepts either directory separator in a relative mounted path option', function () {
+    File::makeDirectory(resource_path('views/admin-pages'), recursive: true, force: true);
+    File::makeDirectory(resource_path('views/site-pages'), recursive: true, force: true);
+
+    Folio::path(resource_path('views/admin-pages'));
+    Folio::path(resource_path('views/site-pages'));
+
+    $this->artisan('folio:page', [
+        'name' => 'dashboard',
+        '--mount' => str_replace('/', '\\', Project::relativePathOf(resource_path('views/site-pages'))),
+    ])->assertOk();
+
+    expect(resource_path('views/site-pages/dashboard.blade.php'))->toBeFile();
+});
+
+it('automatically uses a single mounted path', function () {
+    File::makeDirectory(resource_path('views/admin-pages'), recursive: true, force: true);
+
+    Folio::path(resource_path('views/admin-pages'))->uri('/admin');
+
+    $this->artisan('folio:page', ['name' => 'dashboard'])->assertOk();
+
+    expect(resource_path('views/admin-pages/dashboard.blade.php'))->toBeFile();
+});
+
+it('treats duplicate registrations of a path as one generator target', function () {
+    File::makeDirectory(resource_path('views/admin-pages'), recursive: true, force: true);
+
+    Folio::path(resource_path('views/admin-pages'))->uri('/admin');
+    Folio::path(resource_path('views/admin-pages'))->uri('/staff')->domain('example.com');
+
+    $this->artisan('folio:page', [
+        'name' => 'dashboard',
+        '--mount' => resource_path('views/admin-pages'),
+    ])->assertOk();
+
+    expect(resource_path('views/admin-pages/dashboard.blade.php'))->toBeFile();
+});
+
+it('uses the first mounted path non-interactively', function () {
+    File::makeDirectory(resource_path('views/admin-pages'), recursive: true, force: true);
+    File::makeDirectory(resource_path('views/site-pages'), recursive: true, force: true);
+
+    Folio::path(resource_path('views/admin-pages'));
+    Folio::path(resource_path('views/site-pages'));
+
+    $exitCode = Artisan::call('folio:page', [
+        'name' => 'dashboard',
+        '--no-interaction' => true,
+    ], new BufferedOutput);
+
+    expect($exitCode)->toBe(0)
+        ->and(resource_path('views/admin-pages/dashboard.blade.php'))->toBeFile();
+});
+
+it('rejects an unknown mounted path', function () {
+    File::makeDirectory(resource_path('views/admin-pages'), recursive: true, force: true);
+
+    Folio::path(resource_path('views/admin-pages'));
+
+    $this->artisan('folio:page', [
+        'name' => 'dashboard',
+        '--mount' => 'workbench/resources/views/missing-pages',
+    ]);
+})->throws(InvalidArgumentException::class, 'is not one of the configured Folio paths');
+
+it('rejects a mount option when no Folio paths are configured', function () {
+    $this->artisan('folio:page', [
+        'name' => 'dashboard',
+        '--mount' => resource_path('views/pages'),
+    ]);
+})->throws(InvalidArgumentException::class, 'may only be used when a Folio path is configured');
+
+it('rejects an empty mount option', function () {
+    File::makeDirectory(resource_path('views/admin-pages'), recursive: true, force: true);
+
+    Folio::path(resource_path('views/admin-pages'));
+
+    $this->artisan('folio:page', [
+        'name' => 'dashboard',
+        '--mount' => '',
+    ]);
+})->throws(InvalidArgumentException::class, 'is not one of the configured Folio paths');

--- a/tests/Feature/Console/MakeCommandTest.php
+++ b/tests/Feature/Console/MakeCommandTest.php
@@ -54,7 +54,7 @@ it('makes a page in a selected mounted path', function () {
     Folio::path(resource_path('views/admin-pages'))->uri('/admin');
     Folio::path(resource_path('views/site-pages'))->uri('/site')->domain('example.com');
 
-    $this->artisan('folio:page', ['name' => 'dashboard', '--force' => true])
+    $this->artisan('folio:page', ['name' => 'dashboard'])
         ->expectsChoice(
             'Which Folio path should the page be created in?',
             Project::relativePathOf(resource_path('views/site-pages')).' (URI: /site, Domain: example.com)',
@@ -184,7 +184,7 @@ it('rejects a mount option when no Folio paths are configured', function () {
         'name' => 'dashboard',
         '--mount' => resource_path('views/pages'),
     ]);
-})->throws(InvalidArgumentException::class, 'may only be used when a Folio path is configured');
+})->throws(InvalidArgumentException::class, 'is not one of the configured Folio paths');
 
 it('rejects an empty mount option', function () {
     File::makeDirectory(resource_path('views/admin-pages'), recursive: true, force: true);

--- a/tests/Feature/Console/MakeCommandTest.php
+++ b/tests/Feature/Console/MakeCommandTest.php
@@ -57,10 +57,10 @@ it('makes a page in a selected mounted path', function () {
     $this->artisan('folio:page', ['name' => 'dashboard', '--force' => true])
         ->expectsChoice(
             'Which Folio path should the page be created in?',
-            resource_path('views/site-pages'),
+            Project::relativePathOf(resource_path('views/site-pages')).' (URI: /site, Domain: example.com)',
             [
-                resource_path('views/admin-pages') => Project::relativePathOf(resource_path('views/admin-pages')).' (URI: /admin)',
-                resource_path('views/site-pages') => Project::relativePathOf(resource_path('views/site-pages')).' (URI: /site, Domain: example.com)',
+                Project::relativePathOf(resource_path('views/admin-pages')).' (URI: /admin)',
+                Project::relativePathOf(resource_path('views/site-pages')).' (URI: /site, Domain: example.com)',
             ],
         )
         ->assertOk();


### PR DESCRIPTION
Folio supports mounting multiple page directories, but `folio:page` always writes to the first configured path.

This change uses a Laravel Prompts selection when multiple paths are available interactively and adds a `--mount` option for scripts and noninteractive use. A single mount is selected automatically, while noninteractive calls without the option retain the existing first-mount behavior.

The prompt identifies each path by its project-relative location, URI, and domain. Duplicate registrations of the same filesystem path are presented as one generator target.

Tests cover interactive selection, absolute and project-relative options, path normalization, duplicate and single mounts, noninteractive behavior, and invalid options.

Validation:

- 218 package tests (470 assertions)
- PHPStan
- Fresh Laravel 13 application exercising interactive, explicit, and noninteractive generation and serving the generated page
